### PR TITLE
Implement automatic build and PyPI publishing with semantic versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,14 @@
-name: Publish to PyPI
+name: Manual Publish to PyPI
 
 on:
-  push:
-    tags:
-      - 'v*'
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,89 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: |
+          uv sync --group dev
+
+      - name: Run tests
+        run: |
+          uv run pytest
+
+      - name: Run linting
+        run: |
+          uv run ruff check
+
+      - name: Run formatting check
+        run: |
+          uv run ruff format --check
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
+      - name: Build package
+        run: |
+          uv build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,177 @@
+name: Automated Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      released: ${{ steps.release.outputs.released }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: |
+          uv sync --group dev
+
+      - name: Run tests
+        run: |
+          uv run pytest
+
+      - name: Run linting
+        run: |
+          uv run ruff check
+
+      - name: Run formatting check
+        run: |
+          uv run ruff format --check
+
+      - name: Determine version bump
+        id: version_bump
+        run: |
+          # Get the latest tag
+          LATEST_TAG=$(git tag -l 'v*' --sort=-version:refname | head -n1)
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0"
+          fi
+
+          echo "Latest tag: $LATEST_TAG"
+
+          # Get commits since last tag
+          COMMITS=$(git log ${LATEST_TAG}..HEAD --oneline --pretty=format:"%s")
+
+          echo "Commits since last tag:"
+          echo "$COMMITS"
+
+          # Determine version bump type based on commit messages
+          BUMP_TYPE="patch"
+
+          if echo "$COMMITS" | grep -qi "BREAKING CHANGE\|breaking:"; then
+            BUMP_TYPE="major"
+          elif echo "$COMMITS" | grep -qi "feat\|feature:"; then
+            BUMP_TYPE="minor"
+          elif echo "$COMMITS" | grep -qi "fix\|bug\|patch:"; then
+            BUMP_TYPE="patch"
+          fi
+
+          echo "Version bump type: $BUMP_TYPE"
+          echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+
+          # Calculate new version
+          CURRENT_VERSION=$(echo $LATEST_TAG | sed 's/v//')
+          if [ "$CURRENT_VERSION" = "0.0.0" ]; then
+            NEW_VERSION="0.1.0"
+          else
+            IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
+            case $BUMP_TYPE in
+              major)
+                NEW_VERSION="$((major + 1)).0.0"
+                ;;
+              minor)
+                NEW_VERSION="$major.$((minor + 1)).0"
+                ;;
+              patch)
+                NEW_VERSION="$major.$minor.$((patch + 1))"
+                ;;
+            esac
+          fi
+
+          echo "New version: $NEW_VERSION"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update version in pyproject.toml
+        id: update_version
+        if: steps.version_bump.outputs.new_version != ''
+        run: |
+          NEW_VERSION="${{ steps.version_bump.outputs.new_version }}"
+          sed -i "s/version = \"[^\"]*\"/version = \"$NEW_VERSION\"/" pyproject.toml
+
+          echo "Updated pyproject.toml version to $NEW_VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump version to $NEW_VERSION"
+          git push
+
+      - name: Create GitHub Release
+        id: release
+        if: steps.version_bump.outputs.new_version != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_VERSION="${{ steps.version_bump.outputs.new_version }}"
+          BUMP_TYPE="${{ steps.version_bump.outputs.bump_type }}"
+
+          # Create tag
+          git tag "v$NEW_VERSION"
+          git push origin "v$NEW_VERSION"
+
+          # Create release
+          gh release create "v$NEW_VERSION" \
+            --title "Release v$NEW_VERSION" \
+            --notes "## Changes in this release
+
+          This release was automatically generated based on commit messages.
+
+          Version bump type: $BUMP_TYPE
+
+          ### Recent commits:
+          $(git log --oneline --since="1 day ago" --pretty=format:"- %s")" \
+            --latest
+
+          echo "released=true" >> $GITHUB_OUTPUT
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+  publish:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.release.outputs.version }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
+      - name: Build package
+        run: |
+          uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -124,23 +124,53 @@ class TestLimitOrderBook:
 
 ### Commit Messages
 
-Use clear, descriptive commit messages:
+This project uses **automated semantic versioning** based on conventional commit messages. When code is merged to `main`, the system automatically:
 
-- **Good**: `Add support for ITCH 5.1 message format`
-- **Good**: `Fix memory leak in order book processing`
-- **Bad**: `Fix bug`
-- **Bad**: `Update code`
+1. Analyzes commit messages since the last release
+2. Determines the version bump type (major, minor, or patch)
+3. Updates the version in `pyproject.toml`
+4. Creates a GitHub release with a new tag
+5. Publishes the package to PyPI
 
-Format:
+#### Conventional Commit Format
+
+Use these commit message patterns to trigger appropriate version bumps:
+
+**Major Version Bump (Breaking Changes):**
+- `BREAKING CHANGE:` in commit body
+- `breaking:` prefix in commit message
+
+**Minor Version Bump (New Features):**
+- `feat:` prefix for new features
+- `feature:` prefix for new features
+
+**Patch Version Bump (Bug Fixes):**
+- `fix:` prefix for bug fixes
+- `bug:` prefix for bug fixes
+- `patch:` prefix for patches
+
+**Examples:**
+
+```bash
+# Patch version bump (0.1.0 -> 0.1.1)
+git commit -m "fix: resolve issue with order book reconstruction"
+
+# Minor version bump (0.1.0 -> 0.2.0)
+git commit -m "feat: add support for new message types"
+
+# Major version bump (0.1.0 -> 1.0.0)
+git commit -m "refactor: redesign API for better performance
+
+BREAKING CHANGE: MarketProcessor constructor now requires different parameters"
 ```
-Short description (50 chars or less)
 
-Longer explanation if needed. Wrap at 72 characters.
-Explain what the change does and why it was needed.
+#### Manual Releases
 
-- Use bullet points for multiple changes
-- Reference issue numbers: Fixes #123
-```
+If you need to publish a release manually:
+
+1. Go to the GitHub repository
+2. Navigate to Actions → Manual Publish to PyPI
+3. Click "Run workflow" and specify the version
 
 ## Types of Contributions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ parquet = ["pyarrow>=10.0.0"]
 Repository = "https://github.com/vgreg/MeatPy"
 
 [build-system]
-requires = ["uv", "setuptools", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = ["jupyter>=1.1.1", "pre-commit>=4.2.0", "pytest>=8.4.1", "ruff>=0.12.2"]


### PR DESCRIPTION
## Summary
- Implement automated PyPI publishing workflow with trusted publishing
- Add semantic versioning based on conventional commit messages
- Automatic version bumping and GitHub releases on merge to main
- Update build system to use hatchling for better PyPI compatibility

## Changes Made
- **Updated pyproject.toml**: Changed build backend to hatchling
- **Added .github/workflows/publish.yml**: Manual publishing workflow
- **Added .github/workflows/release.yml**: Automated release workflow that:
  - Analyzes commit messages for version bump type (major/minor/patch)
  - Updates version in pyproject.toml automatically
  - Creates GitHub releases with proper tags
  - Publishes to PyPI using trusted publishing
- **Updated docs/contributing.md**: Added conventional commit documentation

## Conventional Commit Format
- `feat:` → Minor version bump (0.1.0 → 0.2.0)
- `fix:` → Patch version bump (0.1.0 → 0.1.1)
- `BREAKING CHANGE:` → Major version bump (0.1.0 → 1.0.0)

## Test Plan
- [x] GitHub environment configured for PyPI trusted publishing
- [x] Workflows pass linting and formatting checks
- [ ] Test automated release by merging to main
- [ ] Verify version bumping logic works correctly
- [ ] Confirm PyPI publishing succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)