### PR TITLE
Fix workflow failure when no git tags exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,13 @@ jobs:
           echo "Latest tag: $LATEST_TAG"
 
           # Get commits since last tag
-          COMMITS=$(git log ${LATEST_TAG}..HEAD --oneline --pretty=format:"%s")
+          if [ "$LATEST_TAG" = "v0.0.0" ]; then
+            # No tags exist, get all commits
+            COMMITS=$(git log --oneline --pretty=format:"%s")
+          else
+            # Get commits since last tag
+            COMMITS=$(git log ${LATEST_TAG}..HEAD --oneline --pretty=format:"%s")
+          fi
 
           echo "Commits since last tag:"
           echo "$COMMITS"


### PR DESCRIPTION
## Problem
The automated release workflow was failing with:
```
fatal: ambiguous argument 'v0.0.0..HEAD': unknown revision or path not in the working tree.
```

This happens because when there are no existing tags in the repository, the script sets `LATEST_TAG="v0.0.0"` as a fallback, but then tries to use `git log v0.0.0..HEAD` which fails since the `v0.0.0` tag doesn't actually exist.

## Solution
Add a check to handle the case when no tags exist:
- If `LATEST_TAG` is the fallback `v0.0.0`, get all commits with `git log --oneline --pretty=format:"%s"`
- Otherwise, use the normal `git log ${LATEST_TAG}..HEAD` approach

## Testing
- [x] Logic validated for repositories with no tags
- [x] Should work for repositories with existing tags
- [ ] End-to-end test by merging to main

This should fix the workflow and allow the first automated release to be created successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)