### PR TITLE
Fix workflow version calculation and commit issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,23 @@ jobs:
           # Calculate new version
           CURRENT_VERSION=$(echo $LATEST_TAG | sed 's/v//')
           if [ "$CURRENT_VERSION" = "0.0.0" ]; then
-            NEW_VERSION="0.1.0"
+            # No existing tags, get current version from pyproject.toml
+            CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\([^"]*\)"/\1/')
+            echo "Current version from pyproject.toml: $CURRENT_VERSION"
+
+            # Bump based on commit type
+            IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
+            case $BUMP_TYPE in
+              major)
+                NEW_VERSION="$((major + 1)).0.0"
+                ;;
+              minor)
+                NEW_VERSION="$major.$((minor + 1)).0"
+                ;;
+              patch)
+                NEW_VERSION="$major.$minor.$((patch + 1))"
+                ;;
+            esac
           else
             IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
             case $BUMP_TYPE in
@@ -125,11 +141,17 @@ jobs:
           sed -i "s/version = \"[^\"]*\"/version = \"$NEW_VERSION\"/" pyproject.toml
 
           echo "Updated pyproject.toml version to $NEW_VERSION"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
-          git commit -m "chore: bump version to $NEW_VERSION"
-          git push
+
+          # Check if there are any changes to commit
+          if git diff --quiet pyproject.toml; then
+            echo "No version changes to commit"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add pyproject.toml
+            git commit -m "chore: bump version to $NEW_VERSION"
+            git push
+          fi
 
       - name: Create GitHub Release
         id: release


### PR DESCRIPTION
## Problem
The workflow was failing with:
```
nothing to commit, working tree clean
```

This happened because:
1. When no git tags exist, the workflow assumed NEW_VERSION should be "0.1.0"
2. But pyproject.toml already has version = "0.1.0"
3. So the sed command didn't change anything
4. git commit failed because there were no changes

## Solution
1. **Better version calculation**: Read current version from pyproject.toml when no tags exist, then properly calculate the bump
2. **Handle no-changes case**: Check if there are actual changes before trying to commit
3. **Proper version bumping**: Now calculates 0.1.0 → 0.2.0 for minor bumps (since recent commits include "feat:")

## Changes Made
- Read current version from pyproject.toml when LATEST_TAG is v0.0.0 (no tags)
- Only commit version changes if `git diff` shows actual changes
- Proper version bump calculation from current version instead of hardcoded 0.1.0

## Expected Result
With recent "feat:" commits, this should now:
- Calculate current version as 0.1.0 (from pyproject.toml)
- Bump to 0.2.0 (minor version bump)
- Commit the change and create release v0.2.0
- Publish to PyPI

🤖 Generated with [Claude Code](https://claude.ai/code)