### PR TITLE
Use BYPASS_TOKEN for protected branch operations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.BYPASS_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -157,7 +158,7 @@ jobs:
         id: release
         if: steps.version_bump.outputs.should_release == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BYPASS_TOKEN }}
         run: |
           NEW_VERSION="${{ steps.version_bump.outputs.new_version }}"
           BUMP_TYPE="${{ steps.version_bump.outputs.bump_type }}"


### PR DESCRIPTION
## Problem
The automated release workflow is failing because it cannot push to the protected `main` branch:
```
remote: error: GH013: Repository rule violations found for refs/heads/main
remote: - Changes must be made through a pull request
```

## Solution
Use the `BYPASS_TOKEN` (Personal Access Token with bypass permissions) instead of the default `GITHUB_TOKEN` for operations that need to bypass branch protection:

1. **Checkout step**: Use `BYPASS_TOKEN` to ensure proper permissions for git operations
2. **GitHub release creation**: Use `BYPASS_TOKEN` for creating releases and tags
3. **Git push**: The token will allow pushing version updates directly to main

## Changes Made
- Added `token: ${{ secrets.BYPASS_TOKEN }}` to the checkout step
- Changed `GITHUB_TOKEN` to `BYPASS_TOKEN` in the release creation step

## Expected Result
The workflow should now be able to:
- Update the version in pyproject.toml
- Commit and push the version change to main (bypassing branch protection)
- Create a GitHub release with the correct tag
- Publish the package to PyPI

This should finally resolve the automated release workflow issues\!

🤖 Generated with [Claude Code](https://claude.ai/code)