### PR TITLE
Fix documentation links and PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,8 +194,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: v${{ needs.release.outputs.version }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -206,6 +204,13 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           version: "latest"
+
+      - name: Update version for PyPI build
+        run: |
+          NEW_VERSION="${{ needs.release.outputs.version }}"
+          sed -i "s/version = \"[^\"]*\"/version = \"$NEW_VERSION\"/" pyproject.toml
+          echo "Updated pyproject.toml version to $NEW_VERSION for PyPI build"
+          grep "version = " pyproject.toml
 
       - name: Build package
         run: |

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -134,6 +134,6 @@ All notebooks include proper error handling for common issues:
 ## Next Steps
 
 After working through the examples:
-- Explore the [API Reference](../api/overview.md) for advanced usage
+- Explore the API Reference for advanced usage
 - Check the [Contributing Guide](../contributing.md) to add your own examples
 - Review the [Getting Started Guide](getting-started.md) for additional features

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -35,7 +35,7 @@ with ITCH50MessageReader("market_data.txt.gz") as reader:
 
 Other common tasks include:
 
-- [Listing Symbols](guide/01_listing_symbols.md): Extracting unique stock symbols from ITCH files
-- [Extracting Specific Symbols](guide/02_extracting_symbols.md): Creating new ITCH files with only specific symbols
-- [Top of Book Snapshots](guide/03_top_of_book_snapshots.md): Generating snapshots of the top of book state for analysis
-- [Order Book Snapshots](guide/04_full_lob_snapshots): Creating snapshots of the full limit order book state
+- **Listing Symbols**: Extracting unique stock symbols from ITCH files
+- **Extracting Specific Symbols**: Creating new ITCH files with only specific symbols
+- **Top of Book Snapshots**: Generating snapshots of the top of book state for analysis
+- **Order Book Snapshots**: Creating snapshots of the full limit order book state


### PR DESCRIPTION
## Problem
Two issues were preventing the automated release from working completely:

1. **Documentation build failing**: MkDocs strict mode was failing due to broken links:
   - `../api/overview.md` (target doesn't exist)
   - `guide/01_listing_symbols.md` and other notebook links (wrong paths)

2. **PyPI publishing failing**: The publish job was checking out the wrong ref and missing version update

## Solution

### Documentation Fixes
- Remove broken API reference link in `examples.md`
- Fix broken notebook links in `getting-started.md` by removing the paths and using simple text

### PyPI Publishing Fixes
- Remove specific tag checkout in publish job (use main branch instead)
- Add version update step in publish job to ensure correct version for PyPI build
- This ensures the package is built with the correct version number

## Expected Result
After merging this PR, the automated release workflow should:
- ✅ Create GitHub release (already working)
- ✅ Build documentation without errors
- ✅ Publish package to PyPI with correct version

The next merge to main should result in a complete, successful automated release\!

🤖 Generated with [Claude Code](https://claude.ai/code)