### PR TITLE
feat: add support for older ITCH versions (2.0, 3.0, 4.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MeatPy is a Python framework for processing and analyzing high-frequency financial data, specifically designed for Nasdaq ITCH 5.0 format. It provides tools for parsing market messages, reconstructing limit order books, and analyzing market microstructure.
+MeatPy is a Python framework for processing and analyzing high-frequency financial data, specifically designed for Nasdaq ITCH protocol formats. It provides tools for parsing market messages, reconstructing limit order books, and analyzing market microstructure. Supported ITCH versions: 2.0, 3.0, 4.0, 4.1, and 5.0.
 
 ## Development Commands
 
@@ -70,7 +70,11 @@ mkdocs serve
 ### Package Structure
 
 - `src/meatpy/` - Core library code
-  - `itch50/` - ITCH 5.0 specific implementations
+  - `itch50/` - ITCH 5.0 specific implementations (binary, 8-char symbols)
+  - `itch41/` - ITCH 4.1 specific implementations (binary, 8-char symbols)
+  - `itch4/` - ITCH 4.0 specific implementations (binary, 6-char symbols)
+  - `itch3/` - ITCH 3.0 specific implementations (ASCII, 6-char symbols)
+  - `itch2/` - ITCH 2.0 specific implementations (ASCII, 6-char symbols)
   - `event_handlers/` - Event recording and processing handlers
   - `writers/` - Output format writers (CSV, Parquet)
 - `tests/` - Test suite

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MeatPy is a Python framework for processing and analyzing high-frequency financi
 ## 🎯 Key Features
 
 - **📊 Limit Order Book Reconstruction**: Complete order book state tracking with proper handling of all order types and modifications
-- **🏛️ NASDAQ ITCH Support**: Full implementation for ITCH 5.0 and 4.1 protocols with native message parsing
+- **🏛️ NASDAQ ITCH Support**: Full implementation for ITCH 2.0, 3.0, 4.0, 4.1, and 5.0 protocols with native message parsing
 - **⚡ Event-Driven Architecture**: Flexible observer pattern for real-time event processing and analysis
 - **🔒 Type Safety**: Modern Python with comprehensive type hints and generic interfaces for robust data handling
 - **📁 Multiple Output Formats**: Export to CSV, Parquet, or implement custom output formats

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -13,11 +13,21 @@ This guide will help you get started with MeatPy for processing financial market
 
 ### Supported Data Formats
 
-MeatPy currently supports:
+MeatPy supports multiple versions of the NASDAQ ITCH protocol:
 
-- **ITCH 5.0**: NASDAQ's binary market data format
+| Version | Format | Stock Symbol Size | Timestamp | Module |
+|---------|--------|-------------------|-----------|--------|
+| **ITCH 5.0** | Binary | 8 characters | Nanoseconds | `meatpy.itch50` |
+| **ITCH 4.1** | Binary | 8 characters | Nanoseconds | `meatpy.itch41` |
+| **ITCH 4.0** | Binary | 6 characters | Nanoseconds | `meatpy.itch4` |
+| **ITCH 3.0** | ASCII | 6 characters | Milliseconds | `meatpy.itch3` |
+| **ITCH 2.0** | ASCII | 6 characters | Milliseconds | `meatpy.itch2` |
+
+Each version has its own `MessageReader`, `MarketProcessor`, and message classes following the same patterns
 
 ## Basic Usage
+
+### Reading ITCH 5.0 Data (Binary)
 
 The simplest way to read ITCH 5.0 data:
 
@@ -32,6 +42,42 @@ with ITCH50MessageReader("market_data.txt.gz") as reader:
             break
 ```
 
+### Reading Other ITCH Versions
+
+Each ITCH version follows the same interface pattern:
+
+```python
+# ITCH 4.1 (Binary, 8-char symbols)
+from meatpy.itch41 import ITCH41MessageReader, ITCH41MarketProcessor
+
+# ITCH 4.0 (Binary, 6-char symbols)
+from meatpy.itch4 import ITCH4MessageReader, ITCH4MarketProcessor
+
+# ITCH 3.0 (ASCII, separate timestamp messages)
+from meatpy.itch3 import ITCH3MessageReader, ITCH3MarketProcessor
+
+# ITCH 2.0 (ASCII, embedded timestamps)
+from meatpy.itch2 import ITCH2MessageReader, ITCH2MarketProcessor
+```
+
+### Building a Limit Order Book
+
+```python
+import datetime
+from meatpy.itch50 import ITCH50MessageReader, ITCH50MarketProcessor
+
+book_date = datetime.datetime(2021, 8, 13)
+processor = ITCH50MarketProcessor("AAPL", book_date)
+
+with ITCH50MessageReader("market_data.txt.gz") as reader:
+    for message in reader:
+        processor.process_message(message)
+
+# Access the limit order book
+if processor.lob:
+    print(f"Best bid: ${processor.lob.best_bid / 10000:.2f}")
+    print(f"Best ask: ${processor.lob.best_ask / 10000:.2f}")
+```
 
 Other common tasks include:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ MeatPy is a Python framework for processing financial market data, specifically 
 ## Key Features
 
 - **Limit Order Book Processing**: Complete reconstruction and analysis of limit order books
-- **ITCH Support**: Full implementation for NASDAQ ITCH 4.1 and 5.0 formats
+- **ITCH Support**: Full implementation for NASDAQ ITCH 2.0, 3.0, 4.0, 4.1, and 5.0 formats
 - **Event-Driven Architecture**: Extensible framework for real-time market data processing
 - **Type Safety**: Modern Python typing for robust financial data handling
 - **Multiple Output Formats**: Support for CSV, Parquet, and custom formats

--- a/src/meatpy/itch2/__init__.py
+++ b/src/meatpy/itch2/__init__.py
@@ -1,0 +1,38 @@
+"""ITCH 2.0 market data subpackage.
+
+This package provides message types, parsers, processors, and recorders for handling
+ITCH 2.0 market data in MeatPy.
+
+ITCH 2.0 is an ASCII format with timestamps (milliseconds from midnight) embedded
+in each message. It supports 6 message types:
+- S: System Event
+- A: Add Order
+- E: Order Executed
+- X: Order Cancel
+- P: Trade
+- B: Broken Trade
+"""
+
+from .itch2_market_message import (
+    ITCH2MarketMessage,
+    AddOrderMessage,
+    BrokenTradeMessage,
+    OrderCancelMessage,
+    OrderExecutedMessage,
+    SystemEventMessage,
+    TradeMessage,
+)
+from .itch2_market_processor import ITCH2MarketProcessor
+from .itch2_message_reader import ITCH2MessageReader
+
+__all__ = [
+    "ITCH2MarketMessage",
+    "ITCH2MarketProcessor",
+    "ITCH2MessageReader",
+    "AddOrderMessage",
+    "BrokenTradeMessage",
+    "OrderCancelMessage",
+    "OrderExecutedMessage",
+    "SystemEventMessage",
+    "TradeMessage",
+]

--- a/src/meatpy/itch2/itch2_market_message.py
+++ b/src/meatpy/itch2/itch2_market_message.py
@@ -1,0 +1,374 @@
+"""ITCH 2.0 market message types.
+
+This module provides message classes for parsing ITCH 2.0 format market data.
+ITCH 2.0 uses ASCII format with timestamps embedded in each message.
+
+Message Types:
+- S: System Event
+- A: Add Order
+- E: Order Executed
+- X: Order Cancel
+- P: Trade
+- B: Broken Trade
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ..message_reader import MarketMessage
+
+
+class ITCH2MarketMessage(MarketMessage):
+    """Base class for all ITCH 2.0 market messages.
+
+    ITCH 2.0 messages are ASCII format with fixed-width fields.
+    All messages have a timestamp as the first 8 characters (milliseconds
+    from midnight), followed by a single character message type.
+    """
+
+    # Message type character to class mapping (populated by subclasses)
+    _message_types: dict[bytes, type["ITCH2MarketMessage"]] = {}
+    message_type: bytes = b""
+    timestamp: int = 0
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Register message type when subclass is defined."""
+        super().__init_subclass__(**kwargs)
+        if cls.message_type:
+            ITCH2MarketMessage._message_types[cls.message_type] = cls
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "ITCH2MarketMessage":
+        """Parse a message from bytes.
+
+        Args:
+            data: Raw message bytes (ASCII)
+
+        Returns:
+            Appropriate message subclass instance
+
+        Raises:
+            ValueError: If message type is unknown
+        """
+        if len(data) < 9:
+            raise ValueError(f"Message too short: {len(data)} bytes")
+
+        message_type = data[8:9]
+        message_class = cls._message_types.get(message_type)
+        if message_class is None:
+            raise ValueError(f"Unknown message type: {message_type!r}")
+
+        return message_class._from_bytes_data(data)
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "ITCH2MarketMessage":
+        """Parse message-specific data. Override in subclasses."""
+        raise NotImplementedError
+
+    def to_bytes(self) -> bytes:
+        """Serialize message to bytes."""
+        raise NotImplementedError
+
+    def to_json(self) -> str:
+        """Serialize message to JSON."""
+        return json.dumps(self._to_json_data())
+
+    def _to_json_data(self) -> dict[str, Any]:
+        """Return message data as a dictionary for JSON serialization."""
+        raise NotImplementedError
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "ITCH2MarketMessage":
+        """Deserialize message from JSON."""
+        data = json.loads(json_str)
+        message_type = data.get("message_type", "").encode()
+        message_class = cls._message_types.get(message_type)
+        if message_class is None:
+            raise ValueError(f"Unknown message type: {message_type!r}")
+        return message_class._from_json_data(data)
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "ITCH2MarketMessage":
+        """Create message from JSON data. Override in subclasses."""
+        raise NotImplementedError
+
+
+class SystemEventMessage(ITCH2MarketMessage):
+    """System Event Message (S).
+
+    Format: timestamp(8) + type(1) + event_code(1) = 10 chars
+
+    Event codes:
+    - O: Start of messages
+    - S: Start of system hours
+    - Q: Start of market hours
+    - M: End of market hours
+    - E: End of system hours
+    - C: End of messages
+    """
+
+    message_type: bytes = b"S"
+    event_code: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "SystemEventMessage":
+        message = cls()
+        message.timestamp = int(data[0:8])
+        message.event_code = data[9:10]
+        return message
+
+    def to_bytes(self) -> bytes:
+        return f"{self.timestamp:08d}S{self.event_code.decode()}".encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "timestamp": self.timestamp,
+            "event_code": self.event_code.decode(),
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "SystemEventMessage":
+        message = cls()
+        message.timestamp = data["timestamp"]
+        message.event_code = data["event_code"].encode()
+        return message
+
+
+class AddOrderMessage(ITCH2MarketMessage):
+    """Add Order Message (A).
+
+    Format: timestamp(8) + type(1) + order_ref(9) + side(1) + shares(6)
+            + stock(6) + price(10) + display(1) = 42 chars
+
+    Price is in fixed-point format: 6 digits whole + 4 digits decimal (implied).
+    """
+
+    message_type: bytes = b"A"
+    order_ref: int = 0
+    side: bytes = b""
+    shares: int = 0
+    stock: bytes = b""
+    price: int = 0  # Price in 10000ths (4 decimal places)
+    display: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "AddOrderMessage":
+        message = cls()
+        message.timestamp = int(data[0:8])
+        message.order_ref = int(data[9:18])
+        message.side = data[18:19]
+        message.shares = int(data[19:25])
+        message.stock = data[25:31]
+        message.price = int(data[31:41])
+        message.display = data[41:42]
+        return message
+
+    def to_bytes(self) -> bytes:
+        return (
+            f"{self.timestamp:08d}A{self.order_ref:9d}{self.side.decode()}"
+            f"{self.shares:6d}{self.stock.decode():6s}{self.price:010d}"
+            f"{self.display.decode()}"
+        ).encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "timestamp": self.timestamp,
+            "order_ref": self.order_ref,
+            "side": self.side.decode(),
+            "shares": self.shares,
+            "stock": self.stock.decode().rstrip(),
+            "price": self.price,
+            "display": self.display.decode(),
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "AddOrderMessage":
+        message = cls()
+        message.timestamp = data["timestamp"]
+        message.order_ref = data["order_ref"]
+        message.side = data["side"].encode()
+        message.shares = data["shares"]
+        message.stock = data["stock"].ljust(6).encode()
+        message.price = data["price"]
+        message.display = data["display"].encode()
+        return message
+
+
+class OrderExecutedMessage(ITCH2MarketMessage):
+    """Order Executed Message (E).
+
+    Format: timestamp(8) + type(1) + order_ref(9) + shares(6) + match_number(9) = 33 chars
+    """
+
+    message_type: bytes = b"E"
+    order_ref: int = 0
+    shares: int = 0
+    match_number: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "OrderExecutedMessage":
+        message = cls()
+        message.timestamp = int(data[0:8])
+        message.order_ref = int(data[9:18])
+        message.shares = int(data[18:24])
+        message.match_number = int(data[24:33])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return (
+            f"{self.timestamp:08d}E{self.order_ref:9d}"
+            f"{self.shares:6d}{self.match_number:9d}"
+        ).encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "timestamp": self.timestamp,
+            "order_ref": self.order_ref,
+            "shares": self.shares,
+            "match_number": self.match_number,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "OrderExecutedMessage":
+        message = cls()
+        message.timestamp = data["timestamp"]
+        message.order_ref = data["order_ref"]
+        message.shares = data["shares"]
+        message.match_number = data["match_number"]
+        return message
+
+
+class OrderCancelMessage(ITCH2MarketMessage):
+    """Order Cancel Message (X).
+
+    Format: timestamp(8) + type(1) + order_ref(9) + shares(6) = 24 chars
+    """
+
+    message_type: bytes = b"X"
+    order_ref: int = 0
+    shares: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "OrderCancelMessage":
+        message = cls()
+        message.timestamp = int(data[0:8])
+        message.order_ref = int(data[9:18])
+        message.shares = int(data[18:24])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return f"{self.timestamp:08d}X{self.order_ref:9d}{self.shares:6d}".encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "timestamp": self.timestamp,
+            "order_ref": self.order_ref,
+            "shares": self.shares,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "OrderCancelMessage":
+        message = cls()
+        message.timestamp = data["timestamp"]
+        message.order_ref = data["order_ref"]
+        message.shares = data["shares"]
+        return message
+
+
+class TradeMessage(ITCH2MarketMessage):
+    """Trade Message (P).
+
+    Format: timestamp(8) + type(1) + order_ref(9) + side(1) + shares(6)
+            + stock(6) + price(10) + match_number(9) = 50 chars
+    """
+
+    message_type: bytes = b"P"
+    order_ref: int = 0
+    side: bytes = b""
+    shares: int = 0
+    stock: bytes = b""
+    price: int = 0
+    match_number: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "TradeMessage":
+        message = cls()
+        message.timestamp = int(data[0:8])
+        message.order_ref = int(data[9:18])
+        message.side = data[18:19]
+        message.shares = int(data[19:25])
+        message.stock = data[25:31]
+        message.price = int(data[31:41])
+        message.match_number = int(data[41:50])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return (
+            f"{self.timestamp:08d}P{self.order_ref:9d}{self.side.decode()}"
+            f"{self.shares:6d}{self.stock.decode():6s}{self.price:010d}"
+            f"{self.match_number:9d}"
+        ).encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "timestamp": self.timestamp,
+            "order_ref": self.order_ref,
+            "side": self.side.decode(),
+            "shares": self.shares,
+            "stock": self.stock.decode().rstrip(),
+            "price": self.price,
+            "match_number": self.match_number,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "TradeMessage":
+        message = cls()
+        message.timestamp = data["timestamp"]
+        message.order_ref = data["order_ref"]
+        message.side = data["side"].encode()
+        message.shares = data["shares"]
+        message.stock = data["stock"].ljust(6).encode()
+        message.price = data["price"]
+        message.match_number = data["match_number"]
+        return message
+
+
+class BrokenTradeMessage(ITCH2MarketMessage):
+    """Broken Trade Message (B).
+
+    Format: timestamp(8) + type(1) + match_number(9) = 18 chars
+    """
+
+    message_type: bytes = b"B"
+    match_number: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "BrokenTradeMessage":
+        message = cls()
+        message.timestamp = int(data[0:8])
+        message.match_number = int(data[9:18])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return f"{self.timestamp:08d}B{self.match_number:9d}".encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "timestamp": self.timestamp,
+            "match_number": self.match_number,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "BrokenTradeMessage":
+        message = cls()
+        message.timestamp = data["timestamp"]
+        message.match_number = data["match_number"]
+        return message

--- a/src/meatpy/itch2/itch2_market_processor.py
+++ b/src/meatpy/itch2/itch2_market_processor.py
@@ -1,0 +1,265 @@
+"""ITCH 2.0 market processor for limit order book reconstruction.
+
+This module provides the ITCH2MarketProcessor class, which processes ITCH 2.0
+market messages to reconstruct the limit order book and handle trading status updates.
+"""
+
+import datetime
+
+from ..lob import LimitOrderBook, OrderNotFoundError, OrderType
+from ..market_processor import MarketProcessor
+from ..message_reader import MarketMessage
+from ..timestamp import Timestamp
+from ..trading_status import (
+    HaltedTradingStatus,
+    PostTradeTradingStatus,
+    PreTradeTradingStatus,
+    TradeTradingStatus,
+)
+from .itch2_market_message import (
+    AddOrderMessage,
+    BrokenTradeMessage,
+    ITCH2MarketMessage,
+    OrderCancelMessage,
+    OrderExecutedMessage,
+    SystemEventMessage,
+    TradeMessage,
+)
+
+
+class InvalidBuySellIndicatorError(Exception):
+    """Exception raised when an invalid buy/sell indicator is encountered.
+
+    This exception is raised when the buy/sell indicator value is not
+    recognized by the ITCH 2.0 processor.
+    """
+
+    pass
+
+
+class MissingLOBError(Exception):
+    """Exception raised when attempting to perform operations without a LOB.
+
+    This exception is raised when trying to cancel, execute, or modify
+    orders when no limit order book is available.
+    """
+
+    pass
+
+
+class UnknownSystemMessageError(Exception):
+    """Exception raised when an unknown system message is encountered.
+
+    This exception is raised when the system message code is not
+    recognized by the ITCH 2.0 processor.
+    """
+
+    pass
+
+
+class ITCH2MarketProcessor(MarketProcessor[int, int, int, int, dict[str, str]]):
+    """A market processor for ITCH 2.0 format.
+
+    This processor handles ITCH 2.0 market messages and reconstructs the limit
+    order book. It processes order additions, executions, cancellations, and
+    trading status updates.
+
+    ITCH 2.0 is ASCII format with timestamps in milliseconds embedded in each message.
+
+    Attributes:
+        system_status: Current system status code
+    """
+
+    def __init__(self, instrument: str | bytes, book_date: datetime.datetime) -> None:
+        """Initialize the ITCH2MarketProcessor.
+
+        Args:
+            instrument: The instrument symbol to process
+            book_date: The date for the limit order book
+        """
+        super().__init__(instrument, book_date)
+        self.system_status: bytes = b""
+        self.lob: LimitOrderBook[int, int, int, int, dict[str, str]] | None = None
+
+    def adjust_timestamp(self, message_timestamp: int) -> Timestamp:
+        """Adjust the raw timestamp to a datetime object for ITCH 2.0.
+
+        In ITCH 2.0, timestamps are milliseconds from midnight.
+
+        Args:
+            message_timestamp: The message timestamp in milliseconds from midnight
+
+        Returns:
+            A Timestamp object representing the adjusted time
+        """
+        # Convert milliseconds to nanoseconds
+        total_nanoseconds = message_timestamp * 1_000_000
+
+        return Timestamp.from_datetime(
+            self.book_date + datetime.timedelta(milliseconds=message_timestamp),
+            nanoseconds=total_nanoseconds,
+        )
+
+    def process_message(self, message: MarketMessage) -> None:
+        """Process a market message and update the limit order book.
+
+        Args:
+            message: The market message to process
+
+        Raises:
+            TypeError: If the message is not an ITCH2MarketMessage
+        """
+        if not isinstance(message, ITCH2MarketMessage):
+            raise TypeError(f"Expected ITCH2MarketMessage, got {type(message)}")
+
+        # Calculate timestamp from message
+        self.current_timestamp = self.adjust_timestamp(message.timestamp)
+
+        # Process based on message type
+        if isinstance(message, SystemEventMessage):
+            self._process_system_event(message)
+        elif isinstance(message, AddOrderMessage):
+            self._process_add_order(message)
+        elif isinstance(message, OrderExecutedMessage):
+            self._process_order_executed(message)
+        elif isinstance(message, OrderCancelMessage):
+            self._process_order_cancel(message)
+        elif isinstance(message, TradeMessage):
+            self._process_trade(message)
+        elif isinstance(message, BrokenTradeMessage):
+            self._process_broken_trade(message)
+
+        # Notify handlers after processing
+        self.message_event(self.current_timestamp, message)
+
+    def _process_system_event(self, message: SystemEventMessage) -> None:
+        """Process a system event message."""
+        self.system_status = message.event_code
+
+        # Update trading status when system status changes
+        self._update_trading_status()
+
+    def _process_add_order(self, message: AddOrderMessage) -> None:
+        """Process an add order message."""
+        # Check if this message is for our instrument
+        stock_symbol = message.stock.decode().rstrip()
+        if isinstance(self.instrument, bytes):
+            instrument_str = self.instrument.decode().rstrip()
+        else:
+            instrument_str = self.instrument.rstrip()
+
+        if stock_symbol != instrument_str:
+            return
+
+        if self.lob is None:
+            self.lob = LimitOrderBook[int, int, int, int, dict[str, str]](
+                self.current_timestamp
+            )
+
+        # Determine order type from side indicator
+        if message.side == b"B":
+            order_type = OrderType.BID
+        elif message.side == b"S":
+            order_type = OrderType.ASK
+        else:
+            raise InvalidBuySellIndicatorError(f"Invalid side: {message.side}")
+
+        # Add order to the book
+        self.lob.enter_quote(
+            timestamp=self.current_timestamp,
+            price=message.price,
+            volume=message.shares,
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_order_executed(self, message: OrderExecutedMessage) -> None:
+        """Process an order executed message."""
+        if self.lob is None:
+            # Order may not be for our instrument
+            return
+
+        # Check if order exists in our book
+        try:
+            order_type = self.lob.find_order_type(message.order_ref)
+        except OrderNotFoundError:
+            # Order not in our book (different instrument)
+            return
+
+        self.lob.execute_trade(
+            timestamp=self.current_timestamp,
+            volume=message.shares,
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_order_cancel(self, message: OrderCancelMessage) -> None:
+        """Process an order cancel message."""
+        if self.lob is None:
+            # Order may not be for our instrument
+            return
+
+        # Check if order exists in our book
+        try:
+            order_type = self.lob.find_order_type(message.order_ref)
+        except OrderNotFoundError:
+            # Order not in our book (different instrument)
+            return
+
+        self.lob.cancel_quote(
+            volume=message.shares,
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_trade(self, message: TradeMessage) -> None:
+        """Process a trade message.
+
+        Trade messages in ITCH 2.0 are for non-displayed orders and
+        don't affect the visible order book.
+        """
+        # Trade messages don't affect the LOB directly
+        # They represent hidden order executions
+        pass
+
+    def _process_broken_trade(self, message: BrokenTradeMessage) -> None:
+        """Process a broken trade message.
+
+        Broken trade messages indicate a previously reported trade has been
+        cancelled. This is informational only and doesn't affect the LOB.
+        """
+        pass
+
+    def _update_trading_status(self) -> None:
+        """Update the trading status based on system status."""
+        new_status = self._determine_trading_status()
+        if new_status != self.trading_status:
+            self.trading_status = new_status
+
+    def _determine_trading_status(self) -> type:
+        """Determine the trading status from system status code.
+
+        Returns:
+            The appropriate trading status class
+        """
+        # System status mapping for ITCH 2.0
+        system_map = {
+            b"O": "start_messages",
+            b"S": "start_system",
+            b"Q": "start_market",
+            b"M": "end_market",
+            b"E": "end_system",
+            b"C": "end_messages",
+        }
+
+        system_status = system_map.get(self.system_status, "unknown")
+
+        # Determine status based on system events
+        if system_status in ["start_messages", "end_messages", "end_system"]:
+            return PostTradeTradingStatus
+        elif system_status == "start_system":
+            return PreTradeTradingStatus
+        elif system_status in ["start_market", "end_market"]:
+            return TradeTradingStatus
+        else:
+            return HaltedTradingStatus

--- a/src/meatpy/itch2/itch2_message_reader.py
+++ b/src/meatpy/itch2/itch2_message_reader.py
@@ -1,0 +1,87 @@
+"""ITCH 2.0 file reader with generator interface.
+
+This module provides the ITCH2MessageReader class, which reads ITCH 2.0 market data files
+and yields structured message objects one at a time using a generator interface.
+
+ITCH 2.0 uses ASCII format with newline-delimited messages.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Generator, Optional
+
+from ..message_reader import MessageReader
+from .itch2_market_message import ITCH2MarketMessage
+
+
+class ITCH2MessageReader(MessageReader):
+    """A market message reader for ITCH 2.0 data with generator interface.
+
+    This reader reads ITCH 2.0 ASCII files and yields message objects one at a time,
+    supporting automatic detection of compressed files (gzip, bzip2, xz, zip).
+
+    Attributes:
+        file_path: Path to the ITCH file to read
+        _file_handle: Internal file handle when used as context manager
+    """
+
+    def __init__(
+        self,
+        file_path: Optional[Path | str] = None,
+    ) -> None:
+        """Initialize the ITCH2MessageReader.
+
+        Args:
+            file_path: Path to the ITCH file to read (optional if using read_file method)
+        """
+        super().__init__(file_path)
+
+    def __iter__(self) -> Generator[ITCH2MarketMessage, None, None]:
+        """Make the reader iterable when used as a context manager."""
+        if self._file_handle is None:
+            raise RuntimeError(
+                "Reader must be used as a context manager to be iterable"
+            )
+        yield from self._read_messages(self._file_handle)
+
+    def read_file(
+        self, file_path: Path | str
+    ) -> Generator[ITCH2MarketMessage, None, None]:
+        """Parse an ITCH 2.0 file and yield messages one at a time.
+
+        Args:
+            file_path: Path to the ITCH file to read
+
+        Yields:
+            ITCH2MarketMessage objects
+        """
+        file_path = Path(file_path)
+        with self._open_file(file_path) as file:
+            yield from self._read_messages(file)
+
+    def _read_messages(self, file) -> Generator[ITCH2MarketMessage, None, None]:
+        """Internal method to read messages from an open file handle.
+
+        ITCH 2.0 format is ASCII with newline-delimited messages.
+
+        Args:
+            file: Open file handle to read from
+
+        Yields:
+            ITCH2MarketMessage objects
+        """
+        for line in file:
+            # Handle both bytes and str (depending on file type)
+            if isinstance(line, str):
+                line = line.encode("latin-1")
+
+            # Strip trailing newline/carriage return
+            line = line.rstrip(b"\r\n")
+
+            # Skip empty lines
+            if not line:
+                continue
+
+            message = ITCH2MarketMessage.from_bytes(line)
+            yield message

--- a/src/meatpy/itch3/__init__.py
+++ b/src/meatpy/itch3/__init__.py
@@ -1,0 +1,71 @@
+"""ITCH 3.0 market data subpackage.
+
+This package provides message types, parsers, processors, and recorders for handling
+ITCH 3.0 market data in MeatPy.
+
+ITCH 3.0 is an ASCII format with separate timestamp messages:
+- T: Seconds from midnight
+- M: Milliseconds offset within current second
+
+Message Types:
+- T: Seconds
+- M: Milliseconds
+- S: System Event
+- R: Stock Directory
+- H: Stock Trading Action
+- L: Market Participant Position
+- A: Add Order (no MPID)
+- F: Add Order (with MPID)
+- E: Order Executed
+- C: Order Executed With Price
+- X: Order Cancel
+- D: Order Delete
+- P: Trade
+- Q: Cross Trade
+- B: Broken Trade
+- I: NOII
+"""
+
+from .itch3_market_message import (
+    ITCH3MarketMessage,
+    AddOrderMessage,
+    AddOrderMPIDMessage,
+    BrokenTradeMessage,
+    CrossTradeMessage,
+    MarketParticipantPositionMessage,
+    MillisecondsMessage,
+    NoiiMessage,
+    OrderCancelMessage,
+    OrderDeleteMessage,
+    OrderExecutedMessage,
+    OrderExecutedPriceMessage,
+    SecondsMessage,
+    StockDirectoryMessage,
+    StockTradingActionMessage,
+    SystemEventMessage,
+    TradeMessage,
+)
+from .itch3_market_processor import ITCH3MarketProcessor
+from .itch3_message_reader import ITCH3MessageReader
+
+__all__ = [
+    "ITCH3MarketMessage",
+    "ITCH3MarketProcessor",
+    "ITCH3MessageReader",
+    "AddOrderMessage",
+    "AddOrderMPIDMessage",
+    "BrokenTradeMessage",
+    "CrossTradeMessage",
+    "MarketParticipantPositionMessage",
+    "MillisecondsMessage",
+    "NoiiMessage",
+    "OrderCancelMessage",
+    "OrderDeleteMessage",
+    "OrderExecutedMessage",
+    "OrderExecutedPriceMessage",
+    "SecondsMessage",
+    "StockDirectoryMessage",
+    "StockTradingActionMessage",
+    "SystemEventMessage",
+    "TradeMessage",
+]

--- a/src/meatpy/itch3/itch3_market_message.py
+++ b/src/meatpy/itch3/itch3_market_message.py
@@ -1,0 +1,810 @@
+"""ITCH 3.0 market message types.
+
+This module provides message classes for parsing ITCH 3.0 format market data.
+ITCH 3.0 uses ASCII format with separate timestamp messages (T for seconds, M for milliseconds).
+
+Message Types:
+- T: Seconds (timestamp base)
+- M: Milliseconds (timestamp offset)
+- S: System Event
+- R: Stock Directory
+- H: Stock Trading Action
+- L: Market Participant Position
+- A: Add Order (no MPID)
+- F: Add Order (with MPID)
+- E: Order Executed
+- C: Order Executed With Price
+- X: Order Cancel
+- D: Order Delete
+- P: Trade (non-cross)
+- Q: Cross Trade
+- B: Broken Trade
+- I: NOII (Net Order Imbalance Indicator)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ..message_reader import MarketMessage
+
+
+class ITCH3MarketMessage(MarketMessage):
+    """Base class for all ITCH 3.0 market messages.
+
+    ITCH 3.0 messages are ASCII format with fixed-width fields.
+    Timestamps are provided via separate T (seconds) and M (milliseconds) messages.
+    """
+
+    # Message type character to class mapping (populated by subclasses)
+    _message_types: dict[bytes, type["ITCH3MarketMessage"]] = {}
+    message_type: bytes = b""
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Register message type when subclass is defined."""
+        super().__init_subclass__(**kwargs)
+        if cls.message_type:
+            ITCH3MarketMessage._message_types[cls.message_type] = cls
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "ITCH3MarketMessage":
+        """Parse a message from bytes.
+
+        Args:
+            data: Raw message bytes (ASCII)
+
+        Returns:
+            Appropriate message subclass instance
+
+        Raises:
+            ValueError: If message type is unknown
+        """
+        if len(data) < 1:
+            raise ValueError(f"Message too short: {len(data)} bytes")
+
+        message_type = data[0:1]
+        message_class = cls._message_types.get(message_type)
+        if message_class is None:
+            raise ValueError(f"Unknown message type: {message_type!r}")
+
+        return message_class._from_bytes_data(data)
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "ITCH3MarketMessage":
+        """Parse message-specific data. Override in subclasses."""
+        raise NotImplementedError
+
+    def to_bytes(self) -> bytes:
+        """Serialize message to bytes."""
+        raise NotImplementedError
+
+    def to_json(self) -> str:
+        """Serialize message to JSON."""
+        return json.dumps(self._to_json_data())
+
+    def _to_json_data(self) -> dict[str, Any]:
+        """Return message data as a dictionary for JSON serialization."""
+        raise NotImplementedError
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "ITCH3MarketMessage":
+        """Deserialize message from JSON."""
+        data = json.loads(json_str)
+        message_type = data.get("message_type", "").encode()
+        message_class = cls._message_types.get(message_type)
+        if message_class is None:
+            raise ValueError(f"Unknown message type: {message_type!r}")
+        return message_class._from_json_data(data)
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "ITCH3MarketMessage":
+        """Create message from JSON data. Override in subclasses."""
+        raise NotImplementedError
+
+
+class SecondsMessage(ITCH3MarketMessage):
+    """Seconds Message (T).
+
+    Format: T + seconds(5) = 6 chars
+    Provides the seconds component of the timestamp.
+    """
+
+    message_type: bytes = b"T"
+    seconds: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "SecondsMessage":
+        message = cls()
+        message.seconds = int(data[1:6])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return f"T{self.seconds:05d}".encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "seconds": self.seconds,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "SecondsMessage":
+        message = cls()
+        message.seconds = data["seconds"]
+        return message
+
+
+class MillisecondsMessage(ITCH3MarketMessage):
+    """Milliseconds Message (M).
+
+    Format: M + milliseconds(3) = 4 chars
+    Provides the milliseconds offset within the current second.
+    """
+
+    message_type: bytes = b"M"
+    milliseconds: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "MillisecondsMessage":
+        message = cls()
+        message.milliseconds = int(data[1:4])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return f"M{self.milliseconds:03d}".encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "milliseconds": self.milliseconds,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "MillisecondsMessage":
+        message = cls()
+        message.milliseconds = data["milliseconds"]
+        return message
+
+
+class SystemEventMessage(ITCH3MarketMessage):
+    """System Event Message (S).
+
+    Format: S + event_code(1) = 2 chars
+
+    Event codes:
+    - O: Start of messages
+    - S: Start of system hours
+    - Q: Start of market hours
+    - M: End of market hours
+    - E: End of system hours
+    - C: End of messages
+    """
+
+    message_type: bytes = b"S"
+    event_code: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "SystemEventMessage":
+        message = cls()
+        message.event_code = data[1:2]
+        return message
+
+    def to_bytes(self) -> bytes:
+        return f"S{self.event_code.decode()}".encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "event_code": self.event_code.decode(),
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "SystemEventMessage":
+        message = cls()
+        message.event_code = data["event_code"].encode()
+        return message
+
+
+class StockDirectoryMessage(ITCH3MarketMessage):
+    """Stock Directory Message (R).
+
+    Format: R + stock(6) + market_category(1) + financial_status(1) + round_lot_size(6) + round_lots_only(1) = 16 chars
+    """
+
+    message_type: bytes = b"R"
+    stock: bytes = b""
+    market_category: bytes = b""
+    financial_status: bytes = b""
+    round_lot_size: int = 0
+    round_lots_only: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "StockDirectoryMessage":
+        message = cls()
+        message.stock = data[1:7]
+        message.market_category = data[7:8]
+        message.financial_status = data[8:9]
+        # round_lot_size is 6 chars, may contain spaces
+        round_lot_str = data[9:15].decode().strip()
+        message.round_lot_size = int(round_lot_str) if round_lot_str else 0
+        message.round_lots_only = data[15:16]
+        return message
+
+    def to_bytes(self) -> bytes:
+        return (
+            f"R{self.stock.decode():6s}{self.market_category.decode()}"
+            f"{self.financial_status.decode()}{self.round_lot_size:6d}"
+            f"{self.round_lots_only.decode()}"
+        ).encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "stock": self.stock.decode().rstrip(),
+            "market_category": self.market_category.decode(),
+            "financial_status": self.financial_status.decode(),
+            "round_lot_size": self.round_lot_size,
+            "round_lots_only": self.round_lots_only.decode(),
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "StockDirectoryMessage":
+        message = cls()
+        message.stock = data["stock"].ljust(6).encode()
+        message.market_category = data["market_category"].encode()
+        message.financial_status = data["financial_status"].encode()
+        message.round_lot_size = data["round_lot_size"]
+        message.round_lots_only = data["round_lots_only"].encode()
+        return message
+
+
+class StockTradingActionMessage(ITCH3MarketMessage):
+    """Stock Trading Action Message (H).
+
+    Format: H + stock(6) + state(1) + reserved(5) = 13 chars
+    """
+
+    message_type: bytes = b"H"
+    stock: bytes = b""
+    state: bytes = b""
+    reserved: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "StockTradingActionMessage":
+        message = cls()
+        message.stock = data[1:7]
+        message.state = data[7:8]
+        message.reserved = data[8:13]
+        return message
+
+    def to_bytes(self) -> bytes:
+        return (
+            f"H{self.stock.decode():6s}{self.state.decode()}"
+            f"{self.reserved.decode():5s}"
+        ).encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "stock": self.stock.decode().rstrip(),
+            "state": self.state.decode(),
+            "reserved": self.reserved.decode().rstrip(),
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "StockTradingActionMessage":
+        message = cls()
+        message.stock = data["stock"].ljust(6).encode()
+        message.state = data["state"].encode()
+        message.reserved = data.get("reserved", "").ljust(5).encode()
+        return message
+
+
+class MarketParticipantPositionMessage(ITCH3MarketMessage):
+    """Market Participant Position Message (L).
+
+    Format: L + stock(6) + mpid(4) + primary_mm(1) + mode(1) + state(1) = 14 chars
+    """
+
+    message_type: bytes = b"L"
+    stock: bytes = b""
+    mpid: bytes = b""
+    primary_mm: bytes = b""
+    mode: bytes = b""
+    state: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "MarketParticipantPositionMessage":
+        message = cls()
+        message.stock = data[1:7]
+        message.mpid = data[7:11]
+        message.primary_mm = data[11:12]
+        message.mode = data[12:13]
+        message.state = data[13:14]
+        return message
+
+    def to_bytes(self) -> bytes:
+        return (
+            f"L{self.stock.decode():6s}{self.mpid.decode():4s}"
+            f"{self.primary_mm.decode()}{self.mode.decode()}{self.state.decode()}"
+        ).encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "stock": self.stock.decode().rstrip(),
+            "mpid": self.mpid.decode().rstrip(),
+            "primary_mm": self.primary_mm.decode(),
+            "mode": self.mode.decode(),
+            "state": self.state.decode(),
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "MarketParticipantPositionMessage":
+        message = cls()
+        message.stock = data["stock"].ljust(6).encode()
+        message.mpid = data["mpid"].ljust(4).encode()
+        message.primary_mm = data["primary_mm"].encode()
+        message.mode = data["mode"].encode()
+        message.state = data["state"].encode()
+        return message
+
+
+class AddOrderMessage(ITCH3MarketMessage):
+    """Add Order Message (A) - no MPID.
+
+    Format: A + order_ref(9) + side(1) + shares(6) + stock(6) + price(10) = 33 chars
+    """
+
+    message_type: bytes = b"A"
+    order_ref: int = 0
+    side: bytes = b""
+    shares: int = 0
+    stock: bytes = b""
+    price: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "AddOrderMessage":
+        message = cls()
+        message.order_ref = int(data[1:10])
+        message.side = data[10:11]
+        message.shares = int(data[11:17])
+        message.stock = data[17:23]
+        message.price = int(data[23:33])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return (
+            f"A{self.order_ref:9d}{self.side.decode()}{self.shares:6d}"
+            f"{self.stock.decode():6s}{self.price:010d}"
+        ).encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "order_ref": self.order_ref,
+            "side": self.side.decode(),
+            "shares": self.shares,
+            "stock": self.stock.decode().rstrip(),
+            "price": self.price,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "AddOrderMessage":
+        message = cls()
+        message.order_ref = data["order_ref"]
+        message.side = data["side"].encode()
+        message.shares = data["shares"]
+        message.stock = data["stock"].ljust(6).encode()
+        message.price = data["price"]
+        return message
+
+
+class AddOrderMPIDMessage(ITCH3MarketMessage):
+    """Add Order Message with MPID (F).
+
+    Format: F + order_ref(9) + side(1) + shares(6) + stock(6) + price(10) + mpid(4) = 37 chars
+    """
+
+    message_type: bytes = b"F"
+    order_ref: int = 0
+    side: bytes = b""
+    shares: int = 0
+    stock: bytes = b""
+    price: int = 0
+    mpid: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "AddOrderMPIDMessage":
+        message = cls()
+        message.order_ref = int(data[1:10])
+        message.side = data[10:11]
+        message.shares = int(data[11:17])
+        message.stock = data[17:23]
+        message.price = int(data[23:33])
+        message.mpid = data[33:37]
+        return message
+
+    def to_bytes(self) -> bytes:
+        return (
+            f"F{self.order_ref:9d}{self.side.decode()}{self.shares:6d}"
+            f"{self.stock.decode():6s}{self.price:010d}{self.mpid.decode():4s}"
+        ).encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "order_ref": self.order_ref,
+            "side": self.side.decode(),
+            "shares": self.shares,
+            "stock": self.stock.decode().rstrip(),
+            "price": self.price,
+            "mpid": self.mpid.decode().rstrip(),
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "AddOrderMPIDMessage":
+        message = cls()
+        message.order_ref = data["order_ref"]
+        message.side = data["side"].encode()
+        message.shares = data["shares"]
+        message.stock = data["stock"].ljust(6).encode()
+        message.price = data["price"]
+        message.mpid = data["mpid"].ljust(4).encode()
+        return message
+
+
+class OrderExecutedMessage(ITCH3MarketMessage):
+    """Order Executed Message (E).
+
+    Format: E + order_ref(9) + shares(6) + match_number(9) = 25 chars
+    """
+
+    message_type: bytes = b"E"
+    order_ref: int = 0
+    shares: int = 0
+    match_number: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "OrderExecutedMessage":
+        message = cls()
+        message.order_ref = int(data[1:10])
+        message.shares = int(data[10:16])
+        message.match_number = int(data[16:25])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return f"E{self.order_ref:9d}{self.shares:6d}{self.match_number:9d}".encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "order_ref": self.order_ref,
+            "shares": self.shares,
+            "match_number": self.match_number,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "OrderExecutedMessage":
+        message = cls()
+        message.order_ref = data["order_ref"]
+        message.shares = data["shares"]
+        message.match_number = data["match_number"]
+        return message
+
+
+class OrderExecutedPriceMessage(ITCH3MarketMessage):
+    """Order Executed With Price Message (C).
+
+    Format: C + order_ref(9) + shares(6) + match_number(9) + printable(1) + price(10) = 36 chars
+    """
+
+    message_type: bytes = b"C"
+    order_ref: int = 0
+    shares: int = 0
+    match_number: int = 0
+    printable: bytes = b""
+    price: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "OrderExecutedPriceMessage":
+        message = cls()
+        message.order_ref = int(data[1:10])
+        message.shares = int(data[10:16])
+        message.match_number = int(data[16:25])
+        message.printable = data[25:26]
+        message.price = int(data[26:36])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return (
+            f"C{self.order_ref:9d}{self.shares:6d}{self.match_number:9d}"
+            f"{self.printable.decode()}{self.price:010d}"
+        ).encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "order_ref": self.order_ref,
+            "shares": self.shares,
+            "match_number": self.match_number,
+            "printable": self.printable.decode(),
+            "price": self.price,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "OrderExecutedPriceMessage":
+        message = cls()
+        message.order_ref = data["order_ref"]
+        message.shares = data["shares"]
+        message.match_number = data["match_number"]
+        message.printable = data["printable"].encode()
+        message.price = data["price"]
+        return message
+
+
+class OrderCancelMessage(ITCH3MarketMessage):
+    """Order Cancel Message (X).
+
+    Format: X + order_ref(9) + shares(6) = 16 chars
+    """
+
+    message_type: bytes = b"X"
+    order_ref: int = 0
+    shares: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "OrderCancelMessage":
+        message = cls()
+        message.order_ref = int(data[1:10])
+        message.shares = int(data[10:16])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return f"X{self.order_ref:9d}{self.shares:6d}".encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "order_ref": self.order_ref,
+            "shares": self.shares,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "OrderCancelMessage":
+        message = cls()
+        message.order_ref = data["order_ref"]
+        message.shares = data["shares"]
+        return message
+
+
+class OrderDeleteMessage(ITCH3MarketMessage):
+    """Order Delete Message (D).
+
+    Format: D + order_ref(9) = 10 chars
+    """
+
+    message_type: bytes = b"D"
+    order_ref: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "OrderDeleteMessage":
+        message = cls()
+        message.order_ref = int(data[1:10])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return f"D{self.order_ref:9d}".encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "order_ref": self.order_ref,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "OrderDeleteMessage":
+        message = cls()
+        message.order_ref = data["order_ref"]
+        return message
+
+
+class TradeMessage(ITCH3MarketMessage):
+    """Trade Message (P).
+
+    Format: P + order_ref(9) + side(1) + shares(6) + stock(6) + price(10) + match_number(9) = 42 chars
+    """
+
+    message_type: bytes = b"P"
+    order_ref: int = 0
+    side: bytes = b""
+    shares: int = 0
+    stock: bytes = b""
+    price: int = 0
+    match_number: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "TradeMessage":
+        message = cls()
+        message.order_ref = int(data[1:10])
+        message.side = data[10:11]
+        message.shares = int(data[11:17])
+        message.stock = data[17:23]
+        message.price = int(data[23:33])
+        message.match_number = int(data[33:42])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return (
+            f"P{self.order_ref:9d}{self.side.decode()}{self.shares:6d}"
+            f"{self.stock.decode():6s}{self.price:010d}{self.match_number:9d}"
+        ).encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "order_ref": self.order_ref,
+            "side": self.side.decode(),
+            "shares": self.shares,
+            "stock": self.stock.decode().rstrip(),
+            "price": self.price,
+            "match_number": self.match_number,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "TradeMessage":
+        message = cls()
+        message.order_ref = data["order_ref"]
+        message.side = data["side"].encode()
+        message.shares = data["shares"]
+        message.stock = data["stock"].ljust(6).encode()
+        message.price = data["price"]
+        message.match_number = data["match_number"]
+        return message
+
+
+class CrossTradeMessage(ITCH3MarketMessage):
+    """Cross Trade Message (Q).
+
+    Format: Q + shares(9) + stock(6) + price(10) + match_number(9) + cross_type(1) = 36 chars
+    """
+
+    message_type: bytes = b"Q"
+    shares: int = 0
+    stock: bytes = b""
+    price: int = 0
+    match_number: int = 0
+    cross_type: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "CrossTradeMessage":
+        message = cls()
+        message.shares = int(data[1:10])
+        message.stock = data[10:16]
+        message.price = int(data[16:26])
+        message.match_number = int(data[26:35])
+        message.cross_type = data[35:36]
+        return message
+
+    def to_bytes(self) -> bytes:
+        return (
+            f"Q{self.shares:09d}{self.stock.decode():6s}{self.price:010d}"
+            f"{self.match_number:9d}{self.cross_type.decode()}"
+        ).encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "shares": self.shares,
+            "stock": self.stock.decode().rstrip(),
+            "price": self.price,
+            "match_number": self.match_number,
+            "cross_type": self.cross_type.decode(),
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "CrossTradeMessage":
+        message = cls()
+        message.shares = data["shares"]
+        message.stock = data["stock"].ljust(6).encode()
+        message.price = data["price"]
+        message.match_number = data["match_number"]
+        message.cross_type = data["cross_type"].encode()
+        return message
+
+
+class BrokenTradeMessage(ITCH3MarketMessage):
+    """Broken Trade Message (B).
+
+    Format: B + match_number(9) = 10 chars
+    """
+
+    message_type: bytes = b"B"
+    match_number: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "BrokenTradeMessage":
+        message = cls()
+        message.match_number = int(data[1:10])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return f"B{self.match_number:9d}".encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "match_number": self.match_number,
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "BrokenTradeMessage":
+        message = cls()
+        message.match_number = data["match_number"]
+        return message
+
+
+class NoiiMessage(ITCH3MarketMessage):
+    """NOII Message (I) - Net Order Imbalance Indicator.
+
+    Format: I + paired_shares(9) + imbalance_shares(9) + imbalance_direction(1)
+            + stock(6) + far_price(10) + near_price(10) + ref_price(10) + cross_type(2) = 58 chars
+    """
+
+    message_type: bytes = b"I"
+    paired_shares: int = 0
+    imbalance_shares: int = 0
+    imbalance_direction: bytes = b""
+    stock: bytes = b""
+    far_price: int = 0
+    near_price: int = 0
+    ref_price: int = 0
+    cross_type: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, data: bytes) -> "NoiiMessage":
+        message = cls()
+        message.paired_shares = int(data[1:10])
+        message.imbalance_shares = int(data[10:19])
+        message.imbalance_direction = data[19:20]
+        message.stock = data[20:26]
+        message.far_price = int(data[26:36])
+        message.near_price = int(data[36:46])
+        message.ref_price = int(data[46:56])
+        message.cross_type = data[56:58]
+        return message
+
+    def to_bytes(self) -> bytes:
+        return (
+            f"I{self.paired_shares:09d}{self.imbalance_shares:09d}"
+            f"{self.imbalance_direction.decode()}{self.stock.decode():6s}"
+            f"{self.far_price:010d}{self.near_price:010d}{self.ref_price:010d}"
+            f"{self.cross_type.decode():2s}"
+        ).encode()
+
+    def _to_json_data(self) -> dict[str, Any]:
+        return {
+            "message_type": self.message_type.decode(),
+            "paired_shares": self.paired_shares,
+            "imbalance_shares": self.imbalance_shares,
+            "imbalance_direction": self.imbalance_direction.decode(),
+            "stock": self.stock.decode().rstrip(),
+            "far_price": self.far_price,
+            "near_price": self.near_price,
+            "ref_price": self.ref_price,
+            "cross_type": self.cross_type.decode().rstrip(),
+        }
+
+    @classmethod
+    def _from_json_data(cls, data: dict[str, Any]) -> "NoiiMessage":
+        message = cls()
+        message.paired_shares = data["paired_shares"]
+        message.imbalance_shares = data["imbalance_shares"]
+        message.imbalance_direction = data["imbalance_direction"].encode()
+        message.stock = data["stock"].ljust(6).encode()
+        message.far_price = data["far_price"]
+        message.near_price = data["near_price"]
+        message.ref_price = data["ref_price"]
+        message.cross_type = data["cross_type"].ljust(2).encode()
+        return message

--- a/src/meatpy/itch3/itch3_market_message.py
+++ b/src/meatpy/itch3/itch3_market_message.py
@@ -280,8 +280,7 @@ class StockTradingActionMessage(ITCH3MarketMessage):
 
     def to_bytes(self) -> bytes:
         return (
-            f"H{self.stock.decode():6s}{self.state.decode()}"
-            f"{self.reserved.decode():5s}"
+            f"H{self.stock.decode():6s}{self.state.decode()}{self.reserved.decode():5s}"
         ).encode()
 
     def _to_json_data(self) -> dict[str, Any]:
@@ -341,7 +340,9 @@ class MarketParticipantPositionMessage(ITCH3MarketMessage):
         }
 
     @classmethod
-    def _from_json_data(cls, data: dict[str, Any]) -> "MarketParticipantPositionMessage":
+    def _from_json_data(
+        cls, data: dict[str, Any]
+    ) -> "MarketParticipantPositionMessage":
         message = cls()
         message.stock = data["stock"].ljust(6).encode()
         message.mpid = data["mpid"].ljust(4).encode()

--- a/src/meatpy/itch3/itch3_market_processor.py
+++ b/src/meatpy/itch3/itch3_market_processor.py
@@ -1,0 +1,426 @@
+"""ITCH 3.0 market processor for limit order book reconstruction.
+
+This module provides the ITCH3MarketProcessor class, which processes ITCH 3.0
+market messages to reconstruct the limit order book and handle trading status updates.
+"""
+
+import datetime
+
+from ..lob import LimitOrderBook, OrderNotFoundError, OrderType
+from ..market_processor import MarketProcessor
+from ..message_reader import MarketMessage
+from ..timestamp import Timestamp
+from ..trading_status import (
+    HaltedTradingStatus,
+    PostTradeTradingStatus,
+    PreTradeTradingStatus,
+    QuoteOnlyTradingStatus,
+    TradeTradingStatus,
+)
+from .itch3_market_message import (
+    AddOrderMessage,
+    AddOrderMPIDMessage,
+    BrokenTradeMessage,
+    CrossTradeMessage,
+    ITCH3MarketMessage,
+    MillisecondsMessage,
+    NoiiMessage,
+    OrderCancelMessage,
+    OrderDeleteMessage,
+    OrderExecutedMessage,
+    OrderExecutedPriceMessage,
+    SecondsMessage,
+    StockDirectoryMessage,
+    StockTradingActionMessage,
+    SystemEventMessage,
+    TradeMessage,
+)
+
+
+class InvalidBuySellIndicatorError(Exception):
+    """Exception raised when an invalid buy/sell indicator is encountered.
+
+    This exception is raised when the buy/sell indicator value is not
+    recognized by the ITCH 3.0 processor.
+    """
+
+    pass
+
+
+class MissingLOBError(Exception):
+    """Exception raised when attempting to perform operations without a LOB.
+
+    This exception is raised when trying to cancel, execute, or modify
+    orders when no limit order book is available.
+    """
+
+    pass
+
+
+class UnknownSystemMessageError(Exception):
+    """Exception raised when an unknown system message is encountered.
+
+    This exception is raised when the system message code is not
+    recognized by the ITCH 3.0 processor.
+    """
+
+    pass
+
+
+class ITCH3MarketProcessor(MarketProcessor[int, int, int, int, dict[str, str]]):
+    """A market processor for ITCH 3.0 format.
+
+    This processor handles ITCH 3.0 market messages and reconstructs the limit
+    order book. It processes order additions, executions, cancellations, and
+    trading status updates.
+
+    ITCH 3.0 is ASCII format with separate T (seconds) and M (milliseconds)
+    timestamp messages.
+
+    Attributes:
+        system_status: Current system status code
+        stock_status: Current stock trading status code
+        current_second: Current second from T message
+        current_millisecond: Current millisecond from M message
+    """
+
+    def __init__(self, instrument: str | bytes, book_date: datetime.datetime) -> None:
+        """Initialize the ITCH3MarketProcessor.
+
+        Args:
+            instrument: The instrument symbol to process
+            book_date: The date for the limit order book
+        """
+        super().__init__(instrument, book_date)
+        self.current_second: int = 0
+        self.current_millisecond: int = 0
+        self.system_status: bytes = b""
+        self.stock_status: bytes = b""
+        self.lob: LimitOrderBook[int, int, int, int, dict[str, str]] | None = None
+
+    def adjust_timestamp(self) -> Timestamp:
+        """Adjust the raw timestamp to a datetime object for ITCH 3.0.
+
+        In ITCH 3.0, timestamps are assembled from:
+        - current_second: from the latest SecondsMessage (T)
+        - current_millisecond: from the latest MillisecondsMessage (M)
+
+        Returns:
+            A Timestamp object representing the adjusted time
+        """
+        # Convert seconds and milliseconds to nanoseconds
+        total_milliseconds = (self.current_second * 1000) + self.current_millisecond
+        total_nanoseconds = total_milliseconds * 1_000_000
+
+        return Timestamp.from_datetime(
+            self.book_date + datetime.timedelta(milliseconds=total_milliseconds),
+            nanoseconds=total_nanoseconds,
+        )
+
+    def process_message(self, message: MarketMessage) -> None:
+        """Process a market message and update the limit order book.
+
+        Args:
+            message: The market message to process
+
+        Raises:
+            TypeError: If the message is not an ITCH3MarketMessage
+        """
+        if not isinstance(message, ITCH3MarketMessage):
+            raise TypeError(f"Expected ITCH3MarketMessage, got {type(message)}")
+
+        # Handle timestamp messages
+        if isinstance(message, SecondsMessage):
+            self.current_second = message.seconds
+            self.current_timestamp = self.adjust_timestamp()
+            self.message_event(self.current_timestamp, message)
+            return
+
+        if isinstance(message, MillisecondsMessage):
+            self.current_millisecond = message.milliseconds
+            self.current_timestamp = self.adjust_timestamp()
+            self.message_event(self.current_timestamp, message)
+            return
+
+        # Update current timestamp for all other messages
+        self.current_timestamp = self.adjust_timestamp()
+
+        # Process based on message type
+        if isinstance(message, SystemEventMessage):
+            self._process_system_event(message)
+        elif isinstance(message, StockDirectoryMessage):
+            self._process_stock_directory(message)
+        elif isinstance(message, StockTradingActionMessage):
+            self._process_stock_trading_action(message)
+        elif isinstance(message, AddOrderMessage):
+            self._process_add_order(message)
+        elif isinstance(message, AddOrderMPIDMessage):
+            self._process_add_order_mpid(message)
+        elif isinstance(message, OrderExecutedMessage):
+            self._process_order_executed(message)
+        elif isinstance(message, OrderExecutedPriceMessage):
+            self._process_order_executed_price(message)
+        elif isinstance(message, OrderCancelMessage):
+            self._process_order_cancel(message)
+        elif isinstance(message, OrderDeleteMessage):
+            self._process_order_delete(message)
+        elif isinstance(message, TradeMessage):
+            self._process_trade(message)
+        elif isinstance(message, CrossTradeMessage):
+            self._process_cross_trade(message)
+        elif isinstance(message, BrokenTradeMessage):
+            self._process_broken_trade(message)
+        elif isinstance(message, NoiiMessage):
+            self._process_noii(message)
+
+        # Notify handlers after processing
+        self.message_event(self.current_timestamp, message)
+
+    def _process_system_event(self, message: SystemEventMessage) -> None:
+        """Process a system event message."""
+        self.system_status = message.event_code
+
+        # Update trading status when system status changes
+        self._update_trading_status()
+
+    def _process_stock_directory(self, message: StockDirectoryMessage) -> None:
+        """Process a stock directory message.
+
+        Stock directory messages provide information about tradeable stocks.
+        """
+        pass  # Informational only
+
+    def _process_stock_trading_action(self, message: StockTradingActionMessage) -> None:
+        """Process a stock trading action message."""
+        # Check if this message is for our instrument
+        stock_symbol = message.stock.decode().rstrip()
+        if isinstance(self.instrument, bytes):
+            instrument_str = self.instrument.decode().rstrip()
+        else:
+            instrument_str = self.instrument.rstrip()
+
+        if stock_symbol != instrument_str:
+            return
+
+        self.stock_status = message.state
+
+        # Update trading status when stock status changes
+        self._update_trading_status()
+
+    def _process_add_order(self, message: AddOrderMessage) -> None:
+        """Process an add order message."""
+        # Check if this message is for our instrument
+        stock_symbol = message.stock.decode().rstrip()
+        if isinstance(self.instrument, bytes):
+            instrument_str = self.instrument.decode().rstrip()
+        else:
+            instrument_str = self.instrument.rstrip()
+
+        if stock_symbol != instrument_str:
+            return
+
+        if self.lob is None:
+            self.lob = LimitOrderBook[int, int, int, int, dict[str, str]](
+                self.current_timestamp
+            )
+
+        # Determine order type from side indicator
+        if message.side == b"B":
+            order_type = OrderType.BID
+        elif message.side == b"S":
+            order_type = OrderType.ASK
+        else:
+            raise InvalidBuySellIndicatorError(f"Invalid side: {message.side}")
+
+        # Add order to the book
+        self.lob.enter_quote(
+            timestamp=self.current_timestamp,
+            price=message.price,
+            volume=message.shares,
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_add_order_mpid(self, message: AddOrderMPIDMessage) -> None:
+        """Process an add order with MPID message."""
+        # Check if this message is for our instrument
+        stock_symbol = message.stock.decode().rstrip()
+        if isinstance(self.instrument, bytes):
+            instrument_str = self.instrument.decode().rstrip()
+        else:
+            instrument_str = self.instrument.rstrip()
+
+        if stock_symbol != instrument_str:
+            return
+
+        if self.lob is None:
+            self.lob = LimitOrderBook[int, int, int, int, dict[str, str]](
+                self.current_timestamp
+            )
+
+        # Determine order type from side indicator
+        if message.side == b"B":
+            order_type = OrderType.BID
+        elif message.side == b"S":
+            order_type = OrderType.ASK
+        else:
+            raise InvalidBuySellIndicatorError(f"Invalid side: {message.side}")
+
+        # Add order to the book (MPID is ignored for book reconstruction)
+        self.lob.enter_quote(
+            timestamp=self.current_timestamp,
+            price=message.price,
+            volume=message.shares,
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_order_executed(self, message: OrderExecutedMessage) -> None:
+        """Process an order executed message."""
+        if self.lob is None:
+            return
+
+        # Check if order exists in our book
+        try:
+            order_type = self.lob.find_order_type(message.order_ref)
+        except OrderNotFoundError:
+            return
+
+        self.lob.execute_trade(
+            timestamp=self.current_timestamp,
+            volume=message.shares,
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_order_executed_price(self, message: OrderExecutedPriceMessage) -> None:
+        """Process an order executed with price message."""
+        if self.lob is None:
+            return
+
+        # Check if order exists in our book
+        try:
+            order_type = self.lob.find_order_type(message.order_ref)
+        except OrderNotFoundError:
+            return
+
+        self.lob.execute_trade(
+            timestamp=self.current_timestamp,
+            volume=message.shares,
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_order_cancel(self, message: OrderCancelMessage) -> None:
+        """Process an order cancel message."""
+        if self.lob is None:
+            return
+
+        # Check if order exists in our book
+        try:
+            order_type = self.lob.find_order_type(message.order_ref)
+        except OrderNotFoundError:
+            return
+
+        self.lob.cancel_quote(
+            volume=message.shares,
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_order_delete(self, message: OrderDeleteMessage) -> None:
+        """Process an order delete message."""
+        if self.lob is None:
+            return
+
+        # Check if order exists in our book
+        try:
+            order_type = self.lob.find_order_type(message.order_ref)
+        except OrderNotFoundError:
+            return
+
+        self.lob.delete_quote(
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_trade(self, message: TradeMessage) -> None:
+        """Process a trade message.
+
+        Trade messages are for non-displayed orders and don't affect
+        the visible order book.
+        """
+        pass
+
+    def _process_cross_trade(self, message: CrossTradeMessage) -> None:
+        """Process a cross trade message.
+
+        Cross trade messages don't affect the order book.
+        """
+        pass
+
+    def _process_broken_trade(self, message: BrokenTradeMessage) -> None:
+        """Process a broken trade message.
+
+        Broken trade messages indicate a previously reported trade has been
+        cancelled. This is informational only and doesn't affect the LOB.
+        """
+        pass
+
+    def _process_noii(self, message: NoiiMessage) -> None:
+        """Process a NOII message.
+
+        NOII messages provide information about order imbalances
+        during cross events.
+        """
+        pass
+
+    def _update_trading_status(self) -> None:
+        """Update the trading status based on system and stock status."""
+        new_status = self._determine_trading_status()
+        if new_status != self.trading_status:
+            self.trading_status = new_status
+
+    def _determine_trading_status(self) -> type:
+        """Determine the trading status from system and stock status codes.
+
+        Returns:
+            The appropriate trading status class
+        """
+        # System status mapping
+        system_map = {
+            b"O": "start_messages",
+            b"S": "start_system",
+            b"Q": "start_market",
+            b"M": "end_market",
+            b"E": "end_system",
+            b"C": "end_messages",
+        }
+
+        # Stock status mapping
+        stock_map = {
+            b"H": "halted",
+            b"P": "paused",
+            b"Q": "quotation_only",
+            b"T": "trading",
+        }
+
+        system_status = system_map.get(self.system_status, "unknown")
+        stock_status = stock_map.get(self.stock_status, "unknown")
+
+        # Determine combined status
+        if system_status in ["start_messages", "end_messages", "end_system"]:
+            return PostTradeTradingStatus
+        elif system_status == "start_system":
+            return PreTradeTradingStatus
+        elif system_status in ["start_market", "end_market"]:
+            if stock_status == "trading":
+                return TradeTradingStatus
+            elif stock_status in ["halted", "paused"]:
+                return HaltedTradingStatus
+            elif stock_status == "quotation_only":
+                return QuoteOnlyTradingStatus
+            else:
+                return PreTradeTradingStatus
+        else:
+            return HaltedTradingStatus

--- a/src/meatpy/itch3/itch3_message_reader.py
+++ b/src/meatpy/itch3/itch3_message_reader.py
@@ -1,0 +1,87 @@
+"""ITCH 3.0 file reader with generator interface.
+
+This module provides the ITCH3MessageReader class, which reads ITCH 3.0 market data files
+and yields structured message objects one at a time using a generator interface.
+
+ITCH 3.0 uses ASCII format with newline-delimited messages.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Generator, Optional
+
+from ..message_reader import MessageReader
+from .itch3_market_message import ITCH3MarketMessage
+
+
+class ITCH3MessageReader(MessageReader):
+    """A market message reader for ITCH 3.0 data with generator interface.
+
+    This reader reads ITCH 3.0 ASCII files and yields message objects one at a time,
+    supporting automatic detection of compressed files (gzip, bzip2, xz, zip).
+
+    Attributes:
+        file_path: Path to the ITCH file to read
+        _file_handle: Internal file handle when used as context manager
+    """
+
+    def __init__(
+        self,
+        file_path: Optional[Path | str] = None,
+    ) -> None:
+        """Initialize the ITCH3MessageReader.
+
+        Args:
+            file_path: Path to the ITCH file to read (optional if using read_file method)
+        """
+        super().__init__(file_path)
+
+    def __iter__(self) -> Generator[ITCH3MarketMessage, None, None]:
+        """Make the reader iterable when used as a context manager."""
+        if self._file_handle is None:
+            raise RuntimeError(
+                "Reader must be used as a context manager to be iterable"
+            )
+        yield from self._read_messages(self._file_handle)
+
+    def read_file(
+        self, file_path: Path | str
+    ) -> Generator[ITCH3MarketMessage, None, None]:
+        """Parse an ITCH 3.0 file and yield messages one at a time.
+
+        Args:
+            file_path: Path to the ITCH file to read
+
+        Yields:
+            ITCH3MarketMessage objects
+        """
+        file_path = Path(file_path)
+        with self._open_file(file_path) as file:
+            yield from self._read_messages(file)
+
+    def _read_messages(self, file) -> Generator[ITCH3MarketMessage, None, None]:
+        """Internal method to read messages from an open file handle.
+
+        ITCH 3.0 format is ASCII with newline-delimited messages.
+
+        Args:
+            file: Open file handle to read from
+
+        Yields:
+            ITCH3MarketMessage objects
+        """
+        for line in file:
+            # Handle both bytes and str (depending on file type)
+            if isinstance(line, str):
+                line = line.encode("latin-1")
+
+            # Strip trailing newline/carriage return
+            line = line.rstrip(b"\r\n")
+
+            # Skip empty lines
+            if not line:
+                continue
+
+            message = ITCH3MarketMessage.from_bytes(line)
+            yield message

--- a/src/meatpy/itch4/__init__.py
+++ b/src/meatpy/itch4/__init__.py
@@ -1,0 +1,66 @@
+"""ITCH 4.0 market data subpackage.
+
+This package provides message types, parsers, processors, and recorders for handling
+ITCH 4.0 market data in MeatPy.
+
+ITCH 4.0 is a binary format similar to ITCH 4.1 but uses 6-character stock symbols
+instead of 8-character symbols. It uses nanosecond timestamps.
+
+Message Types:
+- T: Seconds
+- S: System Event
+- R: Stock Directory
+- H: Stock Trading Action
+- L: Market Participant Position
+- A: Add Order (no MPID)
+- F: Add Order (with MPID)
+- E: Order Executed
+- X: Order Cancel
+- D: Order Delete
+- U: Order Replace
+- P: Trade
+"""
+
+from .itch4_market_message import (
+    ITCH4MarketMessage,
+    AddOrderMessage,
+    AddOrderMPIDMessage,
+    BrokenTradeMessage,
+    CrossTradeMessage,
+    MarketParticipantPositionMessage,
+    NoiiMessage,
+    OrderCancelMessage,
+    OrderDeleteMessage,
+    OrderExecutedMessage,
+    OrderExecutedPriceMessage,
+    OrderReplaceMessage,
+    SecondsMessage,
+    StockDirectoryMessage,
+    StockTradingActionMessage,
+    SystemEventMessage,
+    TradeMessage,
+)
+from .itch4_market_processor import ITCH4MarketProcessor
+from .itch4_message_reader import ITCH4MessageReader
+
+__all__ = [
+    "ITCH4MarketMessage",
+    "ITCH4MarketProcessor",
+    "ITCH4MessageReader",
+    "AddOrderMessage",
+    "AddOrderMPIDMessage",
+    "BrokenTradeMessage",
+    "CrossTradeMessage",
+    "MarketParticipantPositionMessage",
+    "NoiiMessage",
+    "OrderCancelMessage",
+    "OrderDeleteMessage",
+    "OrderExecutedMessage",
+    "OrderExecutedPriceMessage",
+    "OrderReplaceMessage",
+    "SecondsMessage",
+    "StockDirectoryMessage",
+    "StockTradingActionMessage",
+    "SystemEventMessage",
+    "TradeMessage",
+]

--- a/src/meatpy/itch4/itch4_market_message.py
+++ b/src/meatpy/itch4/itch4_market_message.py
@@ -1,0 +1,1278 @@
+"""ITCH 4.0 market message types and parsing.
+
+This module provides classes for parsing and representing ITCH 4.0 market data
+messages. ITCH 4.0 is a binary format similar to ITCH 4.1 but uses 6-character
+stock symbols instead of 8-character symbols.
+
+Message Types:
+- T: Seconds
+- S: System Event
+- R: Stock Directory
+- H: Stock Trading Action
+- L: Market Participant Position
+- A: Add Order (no MPID)
+- F: Add Order (with MPID)
+- E: Order Executed
+- X: Order Cancel
+- D: Order Delete
+- U: Order Replace
+- P: Trade
+"""
+
+import json
+import struct
+
+from ..message_reader import MarketMessage
+
+
+class ITCH4MarketMessage(MarketMessage):
+    """A market message in ITCH 4.0 format.
+
+    This is the base class for all ITCH 4.0 message types. ITCH 4.0 uses
+    binary format with 6-character stock symbols.
+
+    Attributes:
+        timestamp: The nanosecond timestamp offset within the current second
+        type: The message type identifier
+        description: Human-readable description of the message type
+        message_size: The size of the message in bytes
+    """
+
+    type: bytes = b"?"
+    description: str = "Unknown Message"
+    message_size: int = 0
+
+    sysEventCodes = {
+        b"O": "Start of Messages",
+        b"S": "Start of System Hours",
+        b"Q": "Start of Market Hours",
+        b"M": "End of Market Hours",
+        b"E": "End of System Hours",
+        b"C": "End of Messages",
+    }
+
+    market = {
+        b"N": "NYSE",
+        b"A": "AMEX",
+        b"P": "Arca",
+        b"Q": "NASDAQ Global Select",
+        b"G": "NASDAQ Global Market",
+        b"S": "NASDAQ Capital Market",
+        b"Z": "BATS",
+        b" ": "Not available",
+    }
+
+    tradingStates = {
+        b"H": "Halted across all U.S. equity markets / SROs",
+        b"P": "Paused across all U.S. equity markets / SROs",
+        b"Q": "Quotation only period for cross-SRO halt or pause",
+        b"T": "Trading on NASDAQ",
+    }
+
+    primaryMarketMaker = {
+        b"Y": "Primary market maker",
+        b"N": "Non-primary market maker",
+    }
+
+    marketMakerModes = {
+        b"N": "Normal",
+        b"P": "Passive",
+        b"S": "Syndicate",
+        b"R": "Pre-syndicate",
+        b"L": "Penalty",
+    }
+
+    marketParticipantStates = {
+        b"A": "Active",
+        b"E": "Excused",
+        b"W": "Withdrawn",
+        b"S": "Suspended",
+        b"D": "Deleted",
+    }
+
+    def __init__(self) -> None:
+        """Initialize an ITCH4MarketMessage."""
+        self.timestamp: int = 0
+
+    @classmethod
+    def from_bytes(cls, message_data: bytes) -> "ITCH4MarketMessage":
+        """Create a message object from bytes data.
+
+        Args:
+            message_data: The raw message bytes
+
+        Returns:
+            The appropriate message object based on message type
+        """
+        from ..message_reader import UnknownMessageTypeError
+
+        if not message_data:
+            raise ValueError("Empty message data")
+
+        message_type = bytes([message_data[0]])
+
+        # Message type mapping for ITCH 4.0
+        message_classes = {
+            b"T": SecondsMessage,
+            b"S": SystemEventMessage,
+            b"R": StockDirectoryMessage,
+            b"H": StockTradingActionMessage,
+            b"L": MarketParticipantPositionMessage,
+            b"A": AddOrderMessage,
+            b"F": AddOrderMPIDMessage,
+            b"E": OrderExecutedMessage,
+            b"C": OrderExecutedPriceMessage,
+            b"X": OrderCancelMessage,
+            b"D": OrderDeleteMessage,
+            b"U": OrderReplaceMessage,
+            b"P": TradeMessage,
+            b"Q": CrossTradeMessage,
+            b"B": BrokenTradeMessage,
+            b"I": NoiiMessage,
+        }
+
+        message_class = message_classes.get(message_type)
+        if message_class is None:
+            raise UnknownMessageTypeError(f"Unknown message type: {message_type}")
+
+        return message_class._from_bytes_data(message_data)
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "ITCH4MarketMessage":
+        """Create a message object from bytes data."""
+        raise NotImplementedError("Subclasses must implement _from_bytes_data")
+
+    def to_bytes(self) -> bytes:
+        """Convert the message to bytes."""
+        raise NotImplementedError("Subclasses must implement to_bytes")
+
+    def to_json(self) -> str:
+        """Convert the message to JSON format."""
+        data = {
+            "timestamp": self.timestamp,
+            "type": self.type.decode() if isinstance(self.type, bytes) else self.type,
+            "description": self.description,
+        }
+        self._add_json_fields(data)
+        return json.dumps(data)
+
+    def _add_json_fields(self, data: dict) -> None:
+        """Add message-specific fields to JSON data."""
+        pass
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "ITCH4MarketMessage":
+        """Create a message object from JSON string."""
+        from ..message_reader import UnknownMessageTypeError
+
+        data = json.loads(json_str)
+        message_type = data.get("type", "").encode()
+
+        message_classes = {
+            b"T": SecondsMessage,
+            b"S": SystemEventMessage,
+            b"R": StockDirectoryMessage,
+            b"H": StockTradingActionMessage,
+            b"L": MarketParticipantPositionMessage,
+            b"A": AddOrderMessage,
+            b"F": AddOrderMPIDMessage,
+            b"E": OrderExecutedMessage,
+            b"C": OrderExecutedPriceMessage,
+            b"X": OrderCancelMessage,
+            b"D": OrderDeleteMessage,
+            b"U": OrderReplaceMessage,
+            b"P": TradeMessage,
+            b"Q": CrossTradeMessage,
+            b"B": BrokenTradeMessage,
+            b"I": NoiiMessage,
+        }
+
+        message_class = message_classes.get(message_type)
+        if message_class is None:
+            raise UnknownMessageTypeError(f"Unknown message type: {message_type}")
+
+        return message_class._from_json_data(data)
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "ITCH4MarketMessage":
+        """Create a message object from JSON data."""
+        raise NotImplementedError("Subclasses must implement _from_json_data")
+
+
+class SecondsMessage(ITCH4MarketMessage):
+    """Seconds Message (T).
+
+    Format: T(1) + seconds(4) = 5 bytes
+    """
+
+    type = b"T"
+    description = "Seconds Message"
+    message_size = 5
+
+    def __init__(self) -> None:
+        """Initialize a SecondsMessage."""
+        super().__init__()
+        self.seconds: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "SecondsMessage":
+        """Create a SecondsMessage from bytes data."""
+        message = cls()
+        (message.seconds,) = struct.unpack("!I", message_data[1:5])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack("!cI", self.type, self.seconds)
+
+    def _add_json_fields(self, data: dict) -> None:
+        data["seconds"] = self.seconds
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "SecondsMessage":
+        message = cls()
+        message.seconds = data.get("seconds", 0)
+        return message
+
+
+class SystemEventMessage(ITCH4MarketMessage):
+    """System Event Message (S).
+
+    Format: S(1) + timestamp(4) + event_code(1) = 6 bytes
+    """
+
+    type = b"S"
+    description = "System Event Message"
+    message_size = 6
+
+    def __init__(self) -> None:
+        """Initialize a SystemEventMessage."""
+        super().__init__()
+        self.event_code: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "SystemEventMessage":
+        """Create a SystemEventMessage from bytes data."""
+        message = cls()
+        message.timestamp, message.event_code = struct.unpack("!Ic", message_data[1:6])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack("!cIc", self.type, self.timestamp, self.event_code)
+
+    def _add_json_fields(self, data: dict) -> None:
+        data["event_code"] = (
+            self.event_code.decode()
+            if isinstance(self.event_code, bytes)
+            else self.event_code
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "SystemEventMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        event_code = data.get("event_code", " ")
+        if isinstance(event_code, str):
+            event_code = event_code.encode()
+        message.event_code = event_code
+        return message
+
+
+class StockDirectoryMessage(ITCH4MarketMessage):
+    """Stock Directory Message (R).
+
+    Format: R(1) + timestamp(4) + stock(6) + market_category(1) + financial_status(1)
+            + round_lot_size(4) + round_lots_only(1) = 18 bytes
+    """
+
+    type = b"R"
+    description = "Stock Directory Message"
+    message_size = 18
+
+    def __init__(self) -> None:
+        """Initialize a StockDirectoryMessage."""
+        super().__init__()
+        self.stock: bytes = b""
+        self.category: bytes = b""
+        self.status: bytes = b""
+        self.lotsize: int = 0
+        self.lotsonly: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "StockDirectoryMessage":
+        """Create a StockDirectoryMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.stock,
+            message.category,
+            message.status,
+            message.lotsize,
+            message.lotsonly,
+        ) = struct.unpack("!I6sccIc", message_data[1:18])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cI6sccIc",
+            self.type,
+            self.timestamp,
+            self.stock,
+            self.category,
+            self.status,
+            self.lotsize,
+            self.lotsonly,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data.update(
+            {
+                "stock": self.stock.decode().rstrip()
+                if isinstance(self.stock, bytes)
+                else self.stock,
+                "category": self.category.decode()
+                if isinstance(self.category, bytes)
+                else self.category,
+                "status": self.status.decode()
+                if isinstance(self.status, bytes)
+                else self.status,
+                "lotsize": self.lotsize,
+                "lotsonly": self.lotsonly.decode()
+                if isinstance(self.lotsonly, bytes)
+                else self.lotsonly,
+            }
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "StockDirectoryMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        stock = data.get("stock", "")
+        if isinstance(stock, str):
+            stock = stock.ljust(6).encode()
+        message.stock = stock
+        message.lotsize = data.get("lotsize", 0)
+        for field_name in ["category", "status", "lotsonly"]:
+            value = data.get(field_name, " ")
+            if isinstance(value, str):
+                value = value.encode()
+            setattr(message, field_name, value)
+        return message
+
+
+class StockTradingActionMessage(ITCH4MarketMessage):
+    """Stock Trading Action Message (H).
+
+    Format: H(1) + timestamp(4) + stock(6) + state(1) + reserved(5) = 17 bytes
+    """
+
+    type = b"H"
+    description = "Stock Trading Action Message"
+    message_size = 17
+
+    def __init__(self) -> None:
+        """Initialize a StockTradingActionMessage."""
+        super().__init__()
+        self.stock: bytes = b""
+        self.state: bytes = b""
+        self.reserved: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "StockTradingActionMessage":
+        """Create a StockTradingActionMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.stock,
+            message.state,
+            message.reserved,
+        ) = struct.unpack("!I6sc5s", message_data[1:17])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cI6sc5s",
+            self.type,
+            self.timestamp,
+            self.stock,
+            self.state,
+            self.reserved,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data.update(
+            {
+                "stock": self.stock.decode().rstrip()
+                if isinstance(self.stock, bytes)
+                else self.stock,
+                "state": self.state.decode()
+                if isinstance(self.state, bytes)
+                else self.state,
+            }
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "StockTradingActionMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        stock = data.get("stock", "")
+        if isinstance(stock, str):
+            stock = stock.ljust(6).encode()
+        message.stock = stock
+        state = data.get("state", " ")
+        if isinstance(state, str):
+            state = state.encode()
+        message.state = state
+        message.reserved = b"     "
+        return message
+
+
+class MarketParticipantPositionMessage(ITCH4MarketMessage):
+    """Market Participant Position Message (L).
+
+    Format: L(1) + timestamp(4) + mpid(4) + stock(6) + primary(1) + mode(1) + state(1) = 18 bytes
+    """
+
+    type = b"L"
+    description = "Market Participant Position Message"
+    message_size = 18
+
+    def __init__(self) -> None:
+        """Initialize a MarketParticipantPositionMessage."""
+        super().__init__()
+        self.mpid: bytes = b""
+        self.stock: bytes = b""
+        self.primary: bytes = b""
+        self.mode: bytes = b""
+        self.state: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(
+        cls, message_data: bytes
+    ) -> "MarketParticipantPositionMessage":
+        """Create a MarketParticipantPositionMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.mpid,
+            message.stock,
+            message.primary,
+            message.mode,
+            message.state,
+        ) = struct.unpack("!I4s6sccc", message_data[1:18])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cI4s6sccc",
+            self.type,
+            self.timestamp,
+            self.mpid,
+            self.stock,
+            self.primary,
+            self.mode,
+            self.state,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data.update(
+            {
+                "mpid": self.mpid.decode().rstrip()
+                if isinstance(self.mpid, bytes)
+                else self.mpid,
+                "stock": self.stock.decode().rstrip()
+                if isinstance(self.stock, bytes)
+                else self.stock,
+                "primary": self.primary.decode()
+                if isinstance(self.primary, bytes)
+                else self.primary,
+                "mode": self.mode.decode()
+                if isinstance(self.mode, bytes)
+                else self.mode,
+                "state": self.state.decode()
+                if isinstance(self.state, bytes)
+                else self.state,
+            }
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "MarketParticipantPositionMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        stock = data.get("stock", "")
+        if isinstance(stock, str):
+            stock = stock.ljust(6).encode()
+        message.stock = stock
+        mpid = data.get("mpid", "")
+        if isinstance(mpid, str):
+            mpid = mpid.ljust(4).encode()
+        message.mpid = mpid
+        for field_name in ["primary", "mode", "state"]:
+            value = data.get(field_name, " ")
+            if isinstance(value, str):
+                value = value.encode()
+            setattr(message, field_name, value)
+        return message
+
+
+class AddOrderMessage(ITCH4MarketMessage):
+    """Add Order Message (A) - no MPID.
+
+    Format: A(1) + timestamp(4) + order_ref(8) + side(1) + shares(4) + stock(6) + price(4) = 28 bytes
+    """
+
+    type = b"A"
+    description = "Add Order Message"
+    message_size = 28
+
+    def __init__(self) -> None:
+        """Initialize an AddOrderMessage."""
+        super().__init__()
+        self.order_ref: int = 0
+        self.side: bytes = b""
+        self.shares: int = 0
+        self.stock: bytes = b""
+        self.price: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "AddOrderMessage":
+        """Create an AddOrderMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.order_ref,
+            message.side,
+            message.shares,
+            message.stock,
+            message.price,
+        ) = struct.unpack("!IQcI6sI", message_data[1:28])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cIQcI6sI",
+            self.type,
+            self.timestamp,
+            self.order_ref,
+            self.side,
+            self.shares,
+            self.stock,
+            self.price,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data.update(
+            {
+                "order_ref": self.order_ref,
+                "side": self.side.decode()
+                if isinstance(self.side, bytes)
+                else self.side,
+                "shares": self.shares,
+                "stock": self.stock.decode().rstrip()
+                if isinstance(self.stock, bytes)
+                else self.stock,
+                "price": self.price,
+            }
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "AddOrderMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        message.order_ref = data.get("order_ref", 0)
+        message.shares = data.get("shares", 0)
+        message.price = data.get("price", 0)
+        side = data.get("side", " ")
+        if isinstance(side, str):
+            side = side.encode()
+        message.side = side
+        stock = data.get("stock", "")
+        if isinstance(stock, str):
+            stock = stock.ljust(6).encode()
+        message.stock = stock
+        return message
+
+
+class AddOrderMPIDMessage(ITCH4MarketMessage):
+    """Add Order Message with MPID (F).
+
+    Format: F(1) + timestamp(4) + order_ref(8) + side(1) + shares(4) + stock(6) + price(4) + mpid(4) = 32 bytes
+    """
+
+    type = b"F"
+    description = "Add Order MPID Message"
+    message_size = 32
+
+    def __init__(self) -> None:
+        """Initialize an AddOrderMPIDMessage."""
+        super().__init__()
+        self.order_ref: int = 0
+        self.side: bytes = b""
+        self.shares: int = 0
+        self.stock: bytes = b""
+        self.price: int = 0
+        self.mpid: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "AddOrderMPIDMessage":
+        """Create an AddOrderMPIDMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.order_ref,
+            message.side,
+            message.shares,
+            message.stock,
+            message.price,
+            message.mpid,
+        ) = struct.unpack("!IQcI6sI4s", message_data[1:32])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cIQcI6sI4s",
+            self.type,
+            self.timestamp,
+            self.order_ref,
+            self.side,
+            self.shares,
+            self.stock,
+            self.price,
+            self.mpid,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data.update(
+            {
+                "order_ref": self.order_ref,
+                "side": self.side.decode()
+                if isinstance(self.side, bytes)
+                else self.side,
+                "shares": self.shares,
+                "stock": self.stock.decode().rstrip()
+                if isinstance(self.stock, bytes)
+                else self.stock,
+                "price": self.price,
+                "mpid": self.mpid.decode().rstrip()
+                if isinstance(self.mpid, bytes)
+                else self.mpid,
+            }
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "AddOrderMPIDMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        message.order_ref = data.get("order_ref", 0)
+        message.shares = data.get("shares", 0)
+        message.price = data.get("price", 0)
+        side = data.get("side", " ")
+        if isinstance(side, str):
+            side = side.encode()
+        message.side = side
+        stock = data.get("stock", "")
+        if isinstance(stock, str):
+            stock = stock.ljust(6).encode()
+        message.stock = stock
+        mpid = data.get("mpid", "")
+        if isinstance(mpid, str):
+            mpid = mpid.ljust(4).encode()
+        message.mpid = mpid
+        return message
+
+
+class OrderExecutedMessage(ITCH4MarketMessage):
+    """Order Executed Message (E).
+
+    Format: E(1) + timestamp(4) + order_ref(8) + shares(4) + match_number(8) = 25 bytes
+    """
+
+    type = b"E"
+    description = "Order Executed Message"
+    message_size = 25
+
+    def __init__(self) -> None:
+        """Initialize an OrderExecutedMessage."""
+        super().__init__()
+        self.order_ref: int = 0
+        self.shares: int = 0
+        self.match_number: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "OrderExecutedMessage":
+        """Create an OrderExecutedMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.order_ref,
+            message.shares,
+            message.match_number,
+        ) = struct.unpack("!IQIQ", message_data[1:25])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cIQIQ",
+            self.type,
+            self.timestamp,
+            self.order_ref,
+            self.shares,
+            self.match_number,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data.update(
+            {
+                "order_ref": self.order_ref,
+                "shares": self.shares,
+                "match_number": self.match_number,
+            }
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "OrderExecutedMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        message.order_ref = data.get("order_ref", 0)
+        message.shares = data.get("shares", 0)
+        message.match_number = data.get("match_number", 0)
+        return message
+
+
+class OrderExecutedPriceMessage(ITCH4MarketMessage):
+    """Order Executed With Price Message (C).
+
+    Format: C(1) + timestamp(4) + order_ref(8) + shares(4) + match_number(8) + printable(1) + price(4) = 30 bytes
+    """
+
+    type = b"C"
+    description = "Order Executed With Price Message"
+    message_size = 30
+
+    def __init__(self) -> None:
+        """Initialize an OrderExecutedPriceMessage."""
+        super().__init__()
+        self.order_ref: int = 0
+        self.shares: int = 0
+        self.match_number: int = 0
+        self.printable: bytes = b""
+        self.price: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "OrderExecutedPriceMessage":
+        """Create an OrderExecutedPriceMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.order_ref,
+            message.shares,
+            message.match_number,
+            message.printable,
+            message.price,
+        ) = struct.unpack("!IQIQcI", message_data[1:30])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cIQIQcI",
+            self.type,
+            self.timestamp,
+            self.order_ref,
+            self.shares,
+            self.match_number,
+            self.printable,
+            self.price,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data.update(
+            {
+                "order_ref": self.order_ref,
+                "shares": self.shares,
+                "match_number": self.match_number,
+                "printable": self.printable.decode()
+                if isinstance(self.printable, bytes)
+                else self.printable,
+                "price": self.price,
+            }
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "OrderExecutedPriceMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        message.order_ref = data.get("order_ref", 0)
+        message.shares = data.get("shares", 0)
+        message.match_number = data.get("match_number", 0)
+        message.price = data.get("price", 0)
+        printable = data.get("printable", " ")
+        if isinstance(printable, str):
+            printable = printable.encode()
+        message.printable = printable
+        return message
+
+
+class OrderCancelMessage(ITCH4MarketMessage):
+    """Order Cancel Message (X).
+
+    Format: X(1) + timestamp(4) + order_ref(8) + shares(4) = 17 bytes
+    """
+
+    type = b"X"
+    description = "Order Cancel Message"
+    message_size = 17
+
+    def __init__(self) -> None:
+        """Initialize an OrderCancelMessage."""
+        super().__init__()
+        self.order_ref: int = 0
+        self.shares: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "OrderCancelMessage":
+        """Create an OrderCancelMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.order_ref,
+            message.shares,
+        ) = struct.unpack("!IQI", message_data[1:17])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cIQI",
+            self.type,
+            self.timestamp,
+            self.order_ref,
+            self.shares,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data.update(
+            {
+                "order_ref": self.order_ref,
+                "shares": self.shares,
+            }
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "OrderCancelMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        message.order_ref = data.get("order_ref", 0)
+        message.shares = data.get("shares", 0)
+        return message
+
+
+class OrderDeleteMessage(ITCH4MarketMessage):
+    """Order Delete Message (D).
+
+    Format: D(1) + timestamp(4) + order_ref(8) = 13 bytes
+    """
+
+    type = b"D"
+    description = "Order Delete Message"
+    message_size = 13
+
+    def __init__(self) -> None:
+        """Initialize an OrderDeleteMessage."""
+        super().__init__()
+        self.order_ref: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "OrderDeleteMessage":
+        """Create an OrderDeleteMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.order_ref,
+        ) = struct.unpack("!IQ", message_data[1:13])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cIQ",
+            self.type,
+            self.timestamp,
+            self.order_ref,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data["order_ref"] = self.order_ref
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "OrderDeleteMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        message.order_ref = data.get("order_ref", 0)
+        return message
+
+
+class OrderReplaceMessage(ITCH4MarketMessage):
+    """Order Replace Message (U).
+
+    Format: U(1) + timestamp(4) + original_ref(8) + new_ref(8) + shares(4) + price(4) = 29 bytes
+    """
+
+    type = b"U"
+    description = "Order Replace Message"
+    message_size = 29
+
+    def __init__(self) -> None:
+        """Initialize an OrderReplaceMessage."""
+        super().__init__()
+        self.original_ref: int = 0
+        self.new_ref: int = 0
+        self.shares: int = 0
+        self.price: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "OrderReplaceMessage":
+        """Create an OrderReplaceMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.original_ref,
+            message.new_ref,
+            message.shares,
+            message.price,
+        ) = struct.unpack("!IQQII", message_data[1:29])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cIQQII",
+            self.type,
+            self.timestamp,
+            self.original_ref,
+            self.new_ref,
+            self.shares,
+            self.price,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data.update(
+            {
+                "original_ref": self.original_ref,
+                "new_ref": self.new_ref,
+                "shares": self.shares,
+                "price": self.price,
+            }
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "OrderReplaceMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        message.original_ref = data.get("original_ref", 0)
+        message.new_ref = data.get("new_ref", 0)
+        message.shares = data.get("shares", 0)
+        message.price = data.get("price", 0)
+        return message
+
+
+class TradeMessage(ITCH4MarketMessage):
+    """Trade Message (P).
+
+    Format: P(1) + timestamp(4) + order_ref(8) + side(1) + shares(4) + stock(6) + price(4) + match_number(8) = 36 bytes
+    """
+
+    type = b"P"
+    description = "Trade Message"
+    message_size = 36
+
+    def __init__(self) -> None:
+        """Initialize a TradeMessage."""
+        super().__init__()
+        self.order_ref: int = 0
+        self.side: bytes = b""
+        self.shares: int = 0
+        self.stock: bytes = b""
+        self.price: int = 0
+        self.match_number: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "TradeMessage":
+        """Create a TradeMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.order_ref,
+            message.side,
+            message.shares,
+            message.stock,
+            message.price,
+            message.match_number,
+        ) = struct.unpack("!IQcI6sIQ", message_data[1:36])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cIQcI6sIQ",
+            self.type,
+            self.timestamp,
+            self.order_ref,
+            self.side,
+            self.shares,
+            self.stock,
+            self.price,
+            self.match_number,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data.update(
+            {
+                "order_ref": self.order_ref,
+                "side": self.side.decode()
+                if isinstance(self.side, bytes)
+                else self.side,
+                "shares": self.shares,
+                "stock": self.stock.decode().rstrip()
+                if isinstance(self.stock, bytes)
+                else self.stock,
+                "price": self.price,
+                "match_number": self.match_number,
+            }
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "TradeMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        message.order_ref = data.get("order_ref", 0)
+        message.shares = data.get("shares", 0)
+        message.price = data.get("price", 0)
+        message.match_number = data.get("match_number", 0)
+        side = data.get("side", " ")
+        if isinstance(side, str):
+            side = side.encode()
+        message.side = side
+        stock = data.get("stock", "")
+        if isinstance(stock, str):
+            stock = stock.ljust(6).encode()
+        message.stock = stock
+        return message
+
+
+class BrokenTradeMessage(ITCH4MarketMessage):
+    """Broken Trade Message (B).
+
+    Format: B(1) + timestamp(4) + match_number(8) = 13 bytes
+    """
+
+    type = b"B"
+    description = "Broken Trade Message"
+    message_size = 13
+
+    def __init__(self) -> None:
+        """Initialize a BrokenTradeMessage."""
+        super().__init__()
+        self.match_number: int = 0
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "BrokenTradeMessage":
+        """Create a BrokenTradeMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.match_number,
+        ) = struct.unpack("!IQ", message_data[1:13])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cIQ",
+            self.type,
+            self.timestamp,
+            self.match_number,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data["match_number"] = self.match_number
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "BrokenTradeMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        message.match_number = data.get("match_number", 0)
+        return message
+
+
+class CrossTradeMessage(ITCH4MarketMessage):
+    """Cross Trade Message (Q).
+
+    Format: Q(1) + timestamp(4) + shares(8) + stock(6) + price(4) + match_number(8) + cross_type(1) = 32 bytes
+    """
+
+    type = b"Q"
+    description = "Cross Trade Message"
+    message_size = 32
+
+    def __init__(self) -> None:
+        """Initialize a CrossTradeMessage."""
+        super().__init__()
+        self.shares: int = 0
+        self.stock: bytes = b""
+        self.price: int = 0
+        self.match_number: int = 0
+        self.cross_type: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "CrossTradeMessage":
+        """Create a CrossTradeMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.shares,
+            message.stock,
+            message.price,
+            message.match_number,
+            message.cross_type,
+        ) = struct.unpack("!IQ6sIQc", message_data[1:32])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cIQ6sIQc",
+            self.type,
+            self.timestamp,
+            self.shares,
+            self.stock,
+            self.price,
+            self.match_number,
+            self.cross_type,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data.update(
+            {
+                "shares": self.shares,
+                "stock": self.stock.decode().rstrip()
+                if isinstance(self.stock, bytes)
+                else self.stock,
+                "price": self.price,
+                "match_number": self.match_number,
+                "cross_type": self.cross_type.decode()
+                if isinstance(self.cross_type, bytes)
+                else self.cross_type,
+            }
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "CrossTradeMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        message.shares = data.get("shares", 0)
+        message.price = data.get("price", 0)
+        message.match_number = data.get("match_number", 0)
+        stock = data.get("stock", "")
+        if isinstance(stock, str):
+            stock = stock.ljust(6).encode()
+        message.stock = stock
+        cross_type = data.get("cross_type", " ")
+        if isinstance(cross_type, str):
+            cross_type = cross_type.encode()
+        message.cross_type = cross_type
+        return message
+
+
+class NoiiMessage(ITCH4MarketMessage):
+    """NOII Message (I) - Net Order Imbalance Indicator.
+
+    Format: I(1) + timestamp(4) + paired_shares(8) + imbalance_shares(8) + imbalance_direction(1)
+            + stock(6) + far_price(4) + near_price(4) + current_ref_price(4) + cross_type(1) + price_var(1) = 42 bytes
+    """
+
+    type = b"I"
+    description = "NOII Message"
+    message_size = 42
+
+    def __init__(self) -> None:
+        """Initialize a NoiiMessage."""
+        super().__init__()
+        self.paired_shares: int = 0
+        self.imbalance_shares: int = 0
+        self.imbalance_direction: bytes = b""
+        self.stock: bytes = b""
+        self.far_price: int = 0
+        self.near_price: int = 0
+        self.current_ref_price: int = 0
+        self.cross_type: bytes = b""
+        self.price_variation_indicator: bytes = b""
+
+    @classmethod
+    def _from_bytes_data(cls, message_data: bytes) -> "NoiiMessage":
+        """Create a NoiiMessage from bytes data."""
+        message = cls()
+        (
+            message.timestamp,
+            message.paired_shares,
+            message.imbalance_shares,
+            message.imbalance_direction,
+            message.stock,
+            message.far_price,
+            message.near_price,
+            message.current_ref_price,
+            message.cross_type,
+            message.price_variation_indicator,
+        ) = struct.unpack("!IQQc6sIIIcc", message_data[1:42])
+        return message
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "!cIQQc6sIIIcc",
+            self.type,
+            self.timestamp,
+            self.paired_shares,
+            self.imbalance_shares,
+            self.imbalance_direction,
+            self.stock,
+            self.far_price,
+            self.near_price,
+            self.current_ref_price,
+            self.cross_type,
+            self.price_variation_indicator,
+        )
+
+    def _add_json_fields(self, data: dict) -> None:
+        data.update(
+            {
+                "paired_shares": self.paired_shares,
+                "imbalance_shares": self.imbalance_shares,
+                "imbalance_direction": self.imbalance_direction.decode()
+                if isinstance(self.imbalance_direction, bytes)
+                else self.imbalance_direction,
+                "stock": self.stock.decode().rstrip()
+                if isinstance(self.stock, bytes)
+                else self.stock,
+                "far_price": self.far_price,
+                "near_price": self.near_price,
+                "current_ref_price": self.current_ref_price,
+                "cross_type": self.cross_type.decode()
+                if isinstance(self.cross_type, bytes)
+                else self.cross_type,
+                "price_variation_indicator": self.price_variation_indicator.decode()
+                if isinstance(self.price_variation_indicator, bytes)
+                else self.price_variation_indicator,
+            }
+        )
+
+    @classmethod
+    def _from_json_data(cls, data: dict) -> "NoiiMessage":
+        message = cls()
+        message.timestamp = data.get("timestamp", 0)
+        message.paired_shares = data.get("paired_shares", 0)
+        message.imbalance_shares = data.get("imbalance_shares", 0)
+        message.far_price = data.get("far_price", 0)
+        message.near_price = data.get("near_price", 0)
+        message.current_ref_price = data.get("current_ref_price", 0)
+        stock = data.get("stock", "")
+        if isinstance(stock, str):
+            stock = stock.ljust(6).encode()
+        message.stock = stock
+        for field_name in ["imbalance_direction", "cross_type", "price_variation_indicator"]:
+            value = data.get(field_name, " ")
+            if isinstance(value, str):
+                value = value.encode()
+            setattr(message, field_name, value)
+        return message

--- a/src/meatpy/itch4/itch4_market_message.py
+++ b/src/meatpy/itch4/itch4_market_message.py
@@ -1270,7 +1270,11 @@ class NoiiMessage(ITCH4MarketMessage):
         if isinstance(stock, str):
             stock = stock.ljust(6).encode()
         message.stock = stock
-        for field_name in ["imbalance_direction", "cross_type", "price_variation_indicator"]:
+        for field_name in [
+            "imbalance_direction",
+            "cross_type",
+            "price_variation_indicator",
+        ]:
             value = data.get(field_name, " ")
             if isinstance(value, str):
                 value = value.encode()

--- a/src/meatpy/itch4/itch4_market_processor.py
+++ b/src/meatpy/itch4/itch4_market_processor.py
@@ -1,0 +1,434 @@
+"""ITCH 4.0 market processor for limit order book reconstruction.
+
+This module provides the ITCH4MarketProcessor class, which processes ITCH 4.0
+market messages to reconstruct the limit order book and handle trading status updates.
+"""
+
+import datetime
+
+from ..lob import LimitOrderBook, OrderNotFoundError, OrderType
+from ..market_processor import MarketProcessor
+from ..message_reader import MarketMessage
+from ..timestamp import Timestamp
+from ..trading_status import (
+    HaltedTradingStatus,
+    PostTradeTradingStatus,
+    PreTradeTradingStatus,
+    QuoteOnlyTradingStatus,
+    TradeTradingStatus,
+)
+from .itch4_market_message import (
+    AddOrderMessage,
+    AddOrderMPIDMessage,
+    ITCH4MarketMessage,
+    OrderCancelMessage,
+    OrderDeleteMessage,
+    OrderExecutedMessage,
+    OrderExecutedPriceMessage,
+    OrderReplaceMessage,
+    SecondsMessage,
+    StockTradingActionMessage,
+    SystemEventMessage,
+    TradeMessage,
+)
+
+
+class InvalidBuySellIndicatorError(Exception):
+    """Exception raised when an invalid buy/sell indicator is encountered.
+
+    This exception is raised when the buy/sell indicator value is not
+    recognized by the ITCH 4.0 processor.
+    """
+
+    pass
+
+
+class MissingLOBError(Exception):
+    """Exception raised when attempting to perform operations without a LOB.
+
+    This exception is raised when trying to cancel, delete, or replace
+    orders when no limit order book is available.
+    """
+
+    pass
+
+
+class UnknownSystemMessageError(Exception):
+    """Exception raised when an unknown system message is encountered.
+
+    This exception is raised when the system message code is not
+    recognized by the ITCH 4.0 processor.
+    """
+
+    pass
+
+
+class UnknownTradingStateError(Exception):
+    """Exception raised when an unknown trading state is encountered.
+
+    This exception is raised when the trading state code is not
+    recognized by the ITCH 4.0 processor.
+    """
+
+    pass
+
+
+class InvalidTradingStatusError(Exception):
+    """Exception raised when the trading status cannot be determined.
+
+    This exception is raised when the combination of system status,
+    EMC status, and stock status does not correspond to a valid
+    trading status.
+    """
+
+    pass
+
+
+class ITCH4MarketProcessor(MarketProcessor[int, int, int, int, dict[str, str]]):
+    """A market processor for ITCH 4.0 format.
+
+    This processor handles ITCH 4.0 market messages and reconstructs the limit
+    order book. It processes order additions, executions, cancellations, and
+    trading status updates.
+
+    ITCH 4.0 is binary format with nanosecond timestamps, using 6-char stock symbols.
+
+    Attributes:
+        system_status: Current system status code
+        stock_status: Current stock trading status code
+        current_second: Current second from T message
+    """
+
+    def __init__(self, instrument: str | bytes, book_date: datetime.datetime) -> None:
+        """Initialize the ITCH4MarketProcessor.
+
+        Args:
+            instrument: The instrument symbol to process
+            book_date: The date for the limit order book
+        """
+        super().__init__(instrument, book_date)
+        self.current_second: int = 0
+        self.system_status: bytes = b""
+        self.stock_status: bytes = b""
+        self.lob: LimitOrderBook[int, int, int, int, dict[str, str]] | None = None
+
+    def adjust_timestamp(
+        self, current_second: int, message_timestamp: int
+    ) -> Timestamp:
+        """Adjust the raw timestamp to a datetime object for ITCH 4.0.
+
+        In ITCH 4.0, timestamps are assembled from:
+        - current_second: from the latest SecondsMessage
+        - message_timestamp: offset within that second (in nanoseconds)
+
+        Args:
+            current_second: The current second from SecondsMessage
+            message_timestamp: The message timestamp offset in nanoseconds
+
+        Returns:
+            A Timestamp object representing the adjusted time
+        """
+        # Combine second and nanosecond offset
+        total_nanoseconds = (current_second * 1_000_000_000) + message_timestamp
+
+        return Timestamp.from_datetime(
+            self.book_date + datetime.timedelta(microseconds=total_nanoseconds // 1000),
+            nanoseconds=total_nanoseconds,
+        )
+
+    def process_message(self, message: MarketMessage) -> None:
+        """Process a market message and update the limit order book.
+
+        Args:
+            message: The market message to process
+
+        Raises:
+            TypeError: If the message is not an ITCH4MarketMessage
+        """
+        if not isinstance(message, ITCH4MarketMessage):
+            raise TypeError(f"Expected ITCH4MarketMessage, got {type(message)}")
+
+        # Handle SecondsMessage specially - it updates current_second
+        if isinstance(message, SecondsMessage):
+            self.current_second = message.seconds
+            # For SecondsMessage, timestamp is just the seconds converted to nanoseconds
+            self.current_timestamp = self.adjust_timestamp(message.seconds, 0)
+            self.message_event(self.current_timestamp, message)
+            return
+
+        # For all other messages, assemble timestamp from current_second and message timestamp
+        self.current_timestamp = self.adjust_timestamp(
+            self.current_second, message.timestamp
+        )
+
+        # Process based on message type
+        if isinstance(message, SystemEventMessage):
+            self._process_system_event(message)
+        elif isinstance(message, StockTradingActionMessage):
+            self._process_stock_trading_action(message)
+        elif isinstance(message, AddOrderMessage):
+            self._process_add_order(message)
+        elif isinstance(message, AddOrderMPIDMessage):
+            self._process_add_order_mpid(message)
+        elif isinstance(message, OrderExecutedMessage):
+            self._process_order_executed(message)
+        elif isinstance(message, OrderExecutedPriceMessage):
+            self._process_order_executed_price(message)
+        elif isinstance(message, OrderCancelMessage):
+            self._process_order_cancel(message)
+        elif isinstance(message, OrderDeleteMessage):
+            self._process_order_delete(message)
+        elif isinstance(message, OrderReplaceMessage):
+            self._process_order_replace(message)
+        elif isinstance(message, TradeMessage):
+            self._process_trade(message)
+
+        # Notify handlers after processing
+        self.message_event(self.current_timestamp, message)
+
+    def _process_system_event(self, message: SystemEventMessage) -> None:
+        """Process a system event message."""
+        self.system_status = message.event_code
+
+        # Update trading status when system status changes
+        self._update_trading_status()
+
+    def _process_stock_trading_action(self, message: StockTradingActionMessage) -> None:
+        """Process a stock trading action message."""
+        # Check if this message is for our instrument
+        stock_symbol = message.stock.decode().rstrip()
+        if isinstance(self.instrument, bytes):
+            instrument_str = self.instrument.decode().rstrip()
+        else:
+            instrument_str = self.instrument.rstrip()
+
+        if stock_symbol != instrument_str:
+            return
+
+        self.stock_status = message.state
+
+        # Update trading status when stock status changes
+        self._update_trading_status()
+
+    def _process_add_order(self, message: AddOrderMessage) -> None:
+        """Process an add order message."""
+        # Check if this message is for our instrument
+        stock_symbol = message.stock.decode().rstrip()
+        if isinstance(self.instrument, bytes):
+            instrument_str = self.instrument.decode().rstrip()
+        else:
+            instrument_str = self.instrument.rstrip()
+
+        if stock_symbol != instrument_str:
+            return
+
+        if self.lob is None:
+            self.lob = LimitOrderBook[int, int, int, int, dict[str, str]](
+                self.current_timestamp
+            )
+
+        # Determine order type from side indicator
+        if message.side == b"B":
+            order_type = OrderType.BID
+        elif message.side == b"S":
+            order_type = OrderType.ASK
+        else:
+            raise InvalidBuySellIndicatorError(f"Invalid side: {message.side}")
+
+        # Add order to the book
+        self.lob.enter_quote(
+            timestamp=self.current_timestamp,
+            price=message.price,
+            volume=message.shares,
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_add_order_mpid(self, message: AddOrderMPIDMessage) -> None:
+        """Process an add order with MPID message."""
+        # Check if this message is for our instrument
+        stock_symbol = message.stock.decode().rstrip()
+        if isinstance(self.instrument, bytes):
+            instrument_str = self.instrument.decode().rstrip()
+        else:
+            instrument_str = self.instrument.rstrip()
+
+        if stock_symbol != instrument_str:
+            return
+
+        if self.lob is None:
+            self.lob = LimitOrderBook[int, int, int, int, dict[str, str]](
+                self.current_timestamp
+            )
+
+        # Determine order type from side indicator
+        if message.side == b"B":
+            order_type = OrderType.BID
+        elif message.side == b"S":
+            order_type = OrderType.ASK
+        else:
+            raise InvalidBuySellIndicatorError(f"Invalid side: {message.side}")
+
+        # Add order to the book (MPID is ignored for book reconstruction)
+        self.lob.enter_quote(
+            order_id=message.order_ref,
+            order_type=order_type,
+            price=message.price,
+            volume=message.shares,
+            timestamp=self.current_timestamp,
+        )
+
+    def _process_order_executed(self, message: OrderExecutedMessage) -> None:
+        """Process an order executed message."""
+        if self.lob is None:
+            return
+
+        # Check if order exists in our book
+        try:
+            order_type = self.lob.find_order_type(message.order_ref)
+        except OrderNotFoundError:
+            return
+
+        self.lob.execute_trade(
+            timestamp=self.current_timestamp,
+            volume=message.shares,
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_order_executed_price(self, message: OrderExecutedPriceMessage) -> None:
+        """Process an order executed with price message."""
+        if self.lob is None:
+            return
+
+        # Check if order exists in our book
+        try:
+            order_type = self.lob.find_order_type(message.order_ref)
+        except OrderNotFoundError:
+            return
+
+        self.lob.execute_trade(
+            timestamp=self.current_timestamp,
+            volume=message.shares,
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_order_cancel(self, message: OrderCancelMessage) -> None:
+        """Process an order cancel message."""
+        if self.lob is None:
+            return
+
+        # Check if order exists in our book
+        try:
+            order_type = self.lob.find_order_type(message.order_ref)
+        except OrderNotFoundError:
+            return
+
+        self.lob.cancel_quote(
+            volume=message.shares,
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_order_delete(self, message: OrderDeleteMessage) -> None:
+        """Process an order delete message."""
+        if self.lob is None:
+            return
+
+        # Check if order exists in our book
+        try:
+            order_type = self.lob.find_order_type(message.order_ref)
+        except OrderNotFoundError:
+            return
+
+        self.lob.delete_quote(
+            order_id=message.order_ref,
+            order_type=order_type,
+        )
+
+    def _process_order_replace(self, message: OrderReplaceMessage) -> None:
+        """Process an order replace message."""
+        if self.lob is None:
+            return
+
+        # Check if original order exists in our book
+        try:
+            order_type = self.lob.find_order_type(message.original_ref)
+        except OrderNotFoundError:
+            return
+
+        # Delete the original order
+        self.lob.delete_quote(message.original_ref, order_type)
+
+        # Add the new order
+        self.lob.enter_quote(
+            timestamp=self.current_timestamp,
+            price=message.price,
+            volume=message.shares,
+            order_id=message.new_ref,
+            order_type=order_type,
+        )
+
+    def _process_trade(self, message: TradeMessage) -> None:
+        """Process a trade message.
+
+        Trade messages are for non-displayed orders and don't affect
+        the visible order book.
+        """
+        pass
+
+    def _update_trading_status(self) -> None:
+        """Update the trading status based on system and stock status."""
+        new_status = self._determine_trading_status()
+        if new_status != self.trading_status:
+            self.trading_status = new_status
+
+    def _determine_trading_status(self) -> type:
+        """Determine the trading status from system and stock status codes.
+
+        Returns:
+            The appropriate trading status class
+
+        Raises:
+            InvalidTradingStatusError: If status cannot be determined
+        """
+        # System status mapping
+        system_map = {
+            b"O": "start_messages",
+            b"S": "start_system",
+            b"Q": "start_market",
+            b"M": "end_market",
+            b"E": "end_system",
+            b"C": "end_messages",
+        }
+
+        # Stock status mapping
+        stock_map = {
+            b"H": "halted",
+            b"P": "paused",
+            b"Q": "quotation_only",
+            b"T": "trading",
+        }
+
+        system_status = system_map.get(self.system_status, "unknown")
+        stock_status = stock_map.get(self.stock_status, "unknown")
+
+        # Determine combined status
+        if system_status in ["start_messages", "end_messages", "end_system"]:
+            return PostTradeTradingStatus
+        elif system_status == "start_system":
+            return PreTradeTradingStatus
+        elif system_status in ["start_market", "end_market"]:
+            if stock_status == "trading":
+                return TradeTradingStatus
+            elif stock_status in ["halted", "paused"]:
+                return HaltedTradingStatus
+            elif stock_status == "quotation_only":
+                return QuoteOnlyTradingStatus
+            else:
+                return PreTradeTradingStatus
+        else:
+            raise InvalidTradingStatusError(
+                f"Cannot determine status from system={system_status}, stock={stock_status}"
+            )

--- a/src/meatpy/itch4/itch4_message_reader.py
+++ b/src/meatpy/itch4/itch4_message_reader.py
@@ -1,0 +1,131 @@
+"""ITCH 4.0 file reader with generator interface.
+
+This module provides the ITCH4MessageReader class, which reads ITCH 4.0 market data files
+and yields structured message objects one at a time using a generator interface.
+
+ITCH 4.0 uses binary format similar to ITCH 4.1 but with 6-character stock symbols.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Generator, Optional
+
+from ..message_reader import MessageReader
+from .itch4_market_message import ITCH4MarketMessage
+
+
+class ITCH4MessageReader(MessageReader):
+    """A market message reader for ITCH 4.0 data with generator interface.
+
+    This reader reads ITCH 4.0 binary files and yields message objects one at a time,
+    supporting automatic detection of compressed files (gzip, bzip2, xz, zip).
+
+    Attributes:
+        file_path: Path to the ITCH file to read
+        _file_handle: Internal file handle when used as context manager
+    """
+
+    def __init__(
+        self,
+        file_path: Optional[Path | str] = None,
+    ) -> None:
+        """Initialize the ITCH4MessageReader.
+
+        Args:
+            file_path: Path to the ITCH file to read (optional if using read_file method)
+        """
+        super().__init__(file_path)
+
+    def __iter__(self) -> Generator[ITCH4MarketMessage, None, None]:
+        """Make the reader iterable when used as a context manager."""
+        if self._file_handle is None:
+            raise RuntimeError(
+                "Reader must be used as a context manager to be iterable"
+            )
+        yield from self._read_messages(self._file_handle)
+
+    def read_file(
+        self, file_path: Path | str
+    ) -> Generator[ITCH4MarketMessage, None, None]:
+        """Parse an ITCH 4.0 file and yield messages one at a time.
+
+        Args:
+            file_path: Path to the ITCH file to read
+
+        Yields:
+            ITCH4MarketMessage objects
+        """
+        file_path = Path(file_path)
+        with self._open_file(file_path) as file:
+            yield from self._read_messages(file)
+
+    def _read_messages(self, file) -> Generator[ITCH4MarketMessage, None, None]:
+        """Internal method to read messages from an open file handle.
+
+        ITCH 4.0 format is binary with length-prefixed messages:
+        - Byte 0: 0x00 (null byte)
+        - Byte 1: Message length
+        - Bytes 2+: Message payload
+
+        Args:
+            file: Open file handle to read from
+
+        Yields:
+            ITCH4MarketMessage objects
+        """
+        from ..message_reader import InvalidMessageFormatError
+
+        cachesize = 1024 * 4
+
+        data_buffer = file.read(cachesize)
+        data_view = memoryview(data_buffer)
+        offset = 0
+        buflen = len(data_view)
+        eof_reached = False
+
+        while True:
+            # Check if we need more data
+            if offset + 2 > buflen:
+                if eof_reached:
+                    break
+                new_data = file.read(cachesize)
+                if not new_data:
+                    eof_reached = True
+                    break
+                data_buffer = data_view[offset:].tobytes() + new_data
+                data_view = memoryview(data_buffer)
+                buflen = len(data_view)
+                offset = 0
+                continue
+
+            if data_view[offset] != 0:
+                raise InvalidMessageFormatError(f"Unexpected byte: {data_view[offset]}")
+
+            message_len = data_view[offset + 1]
+            message_end = offset + 2 + message_len
+
+            # Check if we have enough data for the complete message
+            if message_end > buflen:
+                if eof_reached:
+                    break
+                new_data = file.read(cachesize)
+                if not new_data:
+                    eof_reached = True
+                    break
+                data_buffer = data_view[offset:].tobytes() + new_data
+                data_view = memoryview(data_buffer)
+                buflen = len(data_view)
+                offset = 0
+                continue
+
+            message = ITCH4MarketMessage.from_bytes(
+                data_view[offset + 2 : message_end].tobytes()
+            )
+
+            yield message
+            offset = message_end
+
+            # Check if we've reached the end of the buffer and EOF
+            if offset >= buflen and eof_reached:
+                break

--- a/src/meatpy/timestamp.py
+++ b/src/meatpy/timestamp.py
@@ -129,6 +129,7 @@ class Timestamp(datetime):
             day=dt.day,
             hour=dt.hour,
             minute=dt.minute,
+            second=dt.second,
             microsecond=dt.microsecond,
             nanoseconds=nanoseconds,
         )

--- a/tests/test_itch2_messages.py
+++ b/tests/test_itch2_messages.py
@@ -1,0 +1,348 @@
+"""Tests for ITCH 2.0 market message functionality."""
+
+import json
+import pytest
+
+from meatpy.itch2.itch2_market_message import (
+    ITCH2MarketMessage,
+    SystemEventMessage,
+    AddOrderMessage,
+    OrderExecutedMessage,
+    OrderCancelMessage,
+    TradeMessage,
+    BrokenTradeMessage,
+)
+
+
+class TestITCH2MarketMessage:
+    """Test the base ITCH2MarketMessage class."""
+
+    def test_from_bytes_unknown_type(self):
+        """Test handling of unknown message types."""
+        data = b"12345678Z" + b"0" * 20
+        with pytest.raises(ValueError, match="Unknown message type"):
+            ITCH2MarketMessage.from_bytes(data)
+
+    def test_from_bytes_too_short(self):
+        """Test handling of message that is too short."""
+        data = b"1234"
+        with pytest.raises(ValueError, match="Message too short"):
+            ITCH2MarketMessage.from_bytes(data)
+
+    def test_from_json_unknown_type(self):
+        """Test handling of unknown message type in JSON."""
+        json_str = json.dumps({"message_type": "Z", "timestamp": 12345})
+        with pytest.raises(ValueError, match="Unknown message type"):
+            ITCH2MarketMessage.from_json(json_str)
+
+
+class TestSystemEventMessage:
+    """Test SystemEventMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: timestamp(8) + type(1) + event_code(1) = 10 chars
+        data = b"12345678SO"  # timestamp=12345678, type=S, event_code=O
+
+        message = ITCH2MarketMessage.from_bytes(data)
+
+        assert isinstance(message, SystemEventMessage)
+        assert message.timestamp == 12345678
+        assert message.event_code == b"O"
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = SystemEventMessage()
+        message.timestamp = 12345678
+        message.event_code = b"O"
+
+        data = message.to_bytes()
+
+        assert data == b"12345678SO"
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = SystemEventMessage()
+        message.timestamp = 12345678
+        message.event_code = b"Q"
+
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["timestamp"] == 12345678
+        assert data["message_type"] == "S"
+        assert data["event_code"] == "Q"
+
+        # Roundtrip
+        new_message = ITCH2MarketMessage.from_json(json_str)
+        assert isinstance(new_message, SystemEventMessage)
+        assert new_message.timestamp == message.timestamp
+        assert new_message.event_code == message.event_code
+
+    def test_all_event_codes(self):
+        """Test all valid event codes."""
+        event_codes = [b"O", b"S", b"Q", b"M", b"E", b"C"]
+        for code in event_codes:
+            data = f"12345678S{code.decode()}".encode()
+            message = ITCH2MarketMessage.from_bytes(data)
+            assert message.event_code == code
+
+
+class TestAddOrderMessage:
+    """Test AddOrderMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: timestamp(8) + type(1) + order_ref(9) + side(1) + shares(6)
+        #         + stock(6) + price(10) + display(1) = 42 chars
+        data = b"12345678A000000001B000100AAPL  0000150000Y"
+
+        message = ITCH2MarketMessage.from_bytes(data)
+
+        assert isinstance(message, AddOrderMessage)
+        assert message.timestamp == 12345678
+        assert message.order_ref == 1
+        assert message.side == b"B"
+        assert message.shares == 100
+        assert message.stock == b"AAPL  "
+        assert message.price == 150000
+        assert message.display == b"Y"
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = AddOrderMessage()
+        message.timestamp = 12345678
+        message.order_ref = 1
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+        message.display = b"Y"
+
+        data = message.to_bytes()
+
+        assert data == b"12345678A        1B   100AAPL  0000150000Y"
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = AddOrderMessage()
+        message.timestamp = 12345678
+        message.order_ref = 999
+        message.side = b"S"
+        message.shares = 200
+        message.stock = b"MSFT  "
+        message.price = 250000
+        message.display = b"N"
+
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["order_ref"] == 999
+        assert data["side"] == "S"
+        assert data["shares"] == 200
+        assert data["stock"] == "MSFT"
+        assert data["price"] == 250000
+
+        # Roundtrip
+        new_message = ITCH2MarketMessage.from_json(json_str)
+        assert isinstance(new_message, AddOrderMessage)
+        assert new_message.order_ref == message.order_ref
+
+
+class TestOrderExecutedMessage:
+    """Test OrderExecutedMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: timestamp(8) + type(1) + order_ref(9) + shares(6) + match_number(9) = 33 chars
+        data = b"12345678E000000001000050000000123"
+
+        message = ITCH2MarketMessage.from_bytes(data)
+
+        assert isinstance(message, OrderExecutedMessage)
+        assert message.timestamp == 12345678
+        assert message.order_ref == 1
+        assert message.shares == 50
+        assert message.match_number == 123
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = OrderExecutedMessage()
+        message.timestamp = 12345678
+        message.order_ref = 1
+        message.shares = 50
+        message.match_number = 123
+
+        data = message.to_bytes()
+
+        assert data == b"12345678E        1    50      123"
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = OrderExecutedMessage()
+        message.timestamp = 12345678
+        message.order_ref = 999
+        message.shares = 100
+        message.match_number = 456
+
+        json_str = message.to_json()
+        new_message = ITCH2MarketMessage.from_json(json_str)
+
+        assert isinstance(new_message, OrderExecutedMessage)
+        assert new_message.order_ref == message.order_ref
+        assert new_message.shares == message.shares
+        assert new_message.match_number == message.match_number
+
+
+class TestOrderCancelMessage:
+    """Test OrderCancelMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: timestamp(8) + type(1) + order_ref(9) + shares(6) = 24 chars
+        data = b"12345678X000000001000025"
+
+        message = ITCH2MarketMessage.from_bytes(data)
+
+        assert isinstance(message, OrderCancelMessage)
+        assert message.timestamp == 12345678
+        assert message.order_ref == 1
+        assert message.shares == 25
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = OrderCancelMessage()
+        message.timestamp = 12345678
+        message.order_ref = 1
+        message.shares = 25
+
+        data = message.to_bytes()
+
+        assert data == b"12345678X        1    25"
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = OrderCancelMessage()
+        message.timestamp = 12345678
+        message.order_ref = 999
+        message.shares = 50
+
+        json_str = message.to_json()
+        new_message = ITCH2MarketMessage.from_json(json_str)
+
+        assert isinstance(new_message, OrderCancelMessage)
+        assert new_message.order_ref == message.order_ref
+        assert new_message.shares == message.shares
+
+
+class TestTradeMessage:
+    """Test TradeMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: timestamp(8) + type(1) + order_ref(9) + side(1) + shares(6)
+        #         + stock(6) + price(10) + match_number(9) = 50 chars
+        data = b"12345678P000000001S000100AAPL  0000150000000000123"
+
+        message = ITCH2MarketMessage.from_bytes(data)
+
+        assert isinstance(message, TradeMessage)
+        assert message.timestamp == 12345678
+        assert message.order_ref == 1
+        assert message.side == b"S"
+        assert message.shares == 100
+        assert message.stock == b"AAPL  "
+        assert message.price == 150000
+        assert message.match_number == 123
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = TradeMessage()
+        message.timestamp = 12345678
+        message.order_ref = 1
+        message.side = b"S"
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+        message.match_number = 123
+
+        data = message.to_bytes()
+
+        assert data == b"12345678P        1S   100AAPL  0000150000      123"
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = TradeMessage()
+        message.timestamp = 12345678
+        message.order_ref = 999
+        message.side = b"B"
+        message.shares = 200
+        message.stock = b"MSFT  "
+        message.price = 250000
+        message.match_number = 456
+
+        json_str = message.to_json()
+        new_message = ITCH2MarketMessage.from_json(json_str)
+
+        assert isinstance(new_message, TradeMessage)
+        assert new_message.order_ref == message.order_ref
+        assert new_message.side == message.side
+
+
+class TestBrokenTradeMessage:
+    """Test BrokenTradeMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: timestamp(8) + type(1) + match_number(9) = 18 chars
+        data = b"12345678B000000123"
+
+        message = ITCH2MarketMessage.from_bytes(data)
+
+        assert isinstance(message, BrokenTradeMessage)
+        assert message.timestamp == 12345678
+        assert message.match_number == 123
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = BrokenTradeMessage()
+        message.timestamp = 12345678
+        message.match_number = 123
+
+        data = message.to_bytes()
+
+        assert data == b"12345678B      123"
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = BrokenTradeMessage()
+        message.timestamp = 12345678
+        message.match_number = 456
+
+        json_str = message.to_json()
+        new_message = ITCH2MarketMessage.from_json(json_str)
+
+        assert isinstance(new_message, BrokenTradeMessage)
+        assert new_message.match_number == message.match_number
+
+
+class TestMessageTypeMappings:
+    """Test that message type mappings work correctly."""
+
+    def test_all_message_types_registered(self):
+        """Verify all message types are properly registered."""
+        # Create minimal data for each type
+        test_cases = [
+            (b"12345678SO", SystemEventMessage),
+            (b"12345678A000000001B000100AAPL  0000150000Y", AddOrderMessage),
+            (b"12345678E000000001000050000000123", OrderExecutedMessage),
+            (b"12345678X000000001000025", OrderCancelMessage),
+            (b"12345678P000000001S000100AAPL  0000150000000000123", TradeMessage),
+            (b"12345678B000000123", BrokenTradeMessage),
+        ]
+
+        for data, expected_class in test_cases:
+            message = ITCH2MarketMessage.from_bytes(data)
+            assert isinstance(message, expected_class), (
+                f"Failed for {expected_class.__name__}"
+            )

--- a/tests/test_itch2_processor.py
+++ b/tests/test_itch2_processor.py
@@ -1,0 +1,312 @@
+"""Tests for ITCH 2.0 market processor functionality."""
+
+import datetime
+import pytest
+
+from meatpy.itch2.itch2_market_processor import (
+    ITCH2MarketProcessor,
+    InvalidBuySellIndicatorError,
+)
+from meatpy.itch2.itch2_market_message import (
+    SystemEventMessage,
+    AddOrderMessage,
+    OrderExecutedMessage,
+    OrderCancelMessage,
+    TradeMessage,
+    BrokenTradeMessage,
+)
+from meatpy.lob import OrderType
+from meatpy.trading_status import (
+    PreTradeTradingStatus,
+    TradeTradingStatus,
+    PostTradeTradingStatus,
+)
+
+
+class TestITCH2MarketProcessor:
+    """Test the ITCH2MarketProcessor class."""
+
+    def test_init(self):
+        """Test processor initialization."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        assert processor.instrument == "AAPL"
+        assert processor.book_date == book_date
+        assert processor.lob is None
+
+    def test_adjust_timestamp(self):
+        """Test timestamp adjustment from milliseconds."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        # 12345678 milliseconds = 12345.678 seconds = ~3 hours 25 minutes 45.678 seconds
+        timestamp = processor.adjust_timestamp(12345678)
+
+        # Should be book_date + 12345678 milliseconds
+        # Timestamp extends datetime, so compare directly
+        expected = book_date + datetime.timedelta(milliseconds=12345678)
+        assert timestamp.year == expected.year
+        assert timestamp.month == expected.month
+        assert timestamp.day == expected.day
+        assert timestamp.hour == expected.hour
+        assert timestamp.minute == expected.minute
+        assert timestamp.second == expected.second
+
+    def test_process_system_event_start_messages(self):
+        """Test processing system event message - start of messages."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        message = SystemEventMessage()
+        message.timestamp = 12345678
+        message.event_code = b"O"
+
+        processor.process_message(message)
+
+        assert processor.system_status == b"O"
+        assert processor.trading_status == PostTradeTradingStatus
+
+    def test_process_system_event_start_market(self):
+        """Test processing system event message - start of market hours."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        message = SystemEventMessage()
+        message.timestamp = 12345678
+        message.event_code = b"Q"
+
+        processor.process_message(message)
+
+        assert processor.system_status == b"Q"
+        assert processor.trading_status == TradeTradingStatus
+
+    def test_process_system_event_start_system(self):
+        """Test processing system event message - start of system hours."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        message = SystemEventMessage()
+        message.timestamp = 12345678
+        message.event_code = b"S"
+
+        processor.process_message(message)
+
+        assert processor.system_status == b"S"
+        assert processor.trading_status == PreTradeTradingStatus
+
+    def test_process_add_order_buy(self):
+        """Test processing add order message - buy side."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMessage()
+        message.timestamp = 12345678
+        message.order_ref = 1
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+        message.display = b"Y"
+
+        processor.process_message(message)
+
+        assert processor.lob is not None
+        order_type = processor.lob.find_order_type(1)
+        assert order_type == OrderType.BID
+
+    def test_process_add_order_sell(self):
+        """Test processing add order message - sell side."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMessage()
+        message.timestamp = 12345678
+        message.order_ref = 2
+        message.side = b"S"
+        message.shares = 200
+        message.stock = b"AAPL  "
+        message.price = 151000
+        message.display = b"Y"
+
+        processor.process_message(message)
+
+        assert processor.lob is not None
+        order_type = processor.lob.find_order_type(2)
+        assert order_type == OrderType.ASK
+
+    def test_process_add_order_invalid_side(self):
+        """Test processing add order with invalid side."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMessage()
+        message.timestamp = 12345678
+        message.order_ref = 1
+        message.side = b"X"  # Invalid side
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+        message.display = b"Y"
+
+        with pytest.raises(InvalidBuySellIndicatorError):
+            processor.process_message(message)
+
+    def test_process_add_order_different_instrument(self):
+        """Test that orders for different instruments are ignored."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMessage()
+        message.timestamp = 12345678
+        message.order_ref = 1
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"MSFT  "  # Different instrument
+        message.price = 150000
+        message.display = b"Y"
+
+        processor.process_message(message)
+
+        # LOB should not be created for different instrument
+        assert processor.lob is None
+
+    def test_process_order_executed(self):
+        """Test processing order executed message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        # First add an order
+        add_msg = AddOrderMessage()
+        add_msg.timestamp = 12345678
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        add_msg.display = b"Y"
+        processor.process_message(add_msg)
+
+        # Then execute part of it
+        exec_msg = OrderExecutedMessage()
+        exec_msg.timestamp = 12345679
+        exec_msg.order_ref = 1
+        exec_msg.shares = 50
+        exec_msg.match_number = 123
+        processor.process_message(exec_msg)
+
+        # Order should still exist with reduced quantity
+        assert processor.lob is not None
+
+    def test_process_order_executed_unknown_order(self):
+        """Test processing order executed for unknown order."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        # Create LOB first
+        add_msg = AddOrderMessage()
+        add_msg.timestamp = 12345678
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        add_msg.display = b"Y"
+        processor.process_message(add_msg)
+
+        # Try to execute unknown order - should not raise
+        exec_msg = OrderExecutedMessage()
+        exec_msg.timestamp = 12345679
+        exec_msg.order_ref = 999  # Unknown order
+        exec_msg.shares = 50
+        exec_msg.match_number = 123
+        processor.process_message(exec_msg)  # Should not raise
+
+    def test_process_order_cancel(self):
+        """Test processing order cancel message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        # First add an order
+        add_msg = AddOrderMessage()
+        add_msg.timestamp = 12345678
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        add_msg.display = b"Y"
+        processor.process_message(add_msg)
+
+        # Then cancel part of it
+        cancel_msg = OrderCancelMessage()
+        cancel_msg.timestamp = 12345679
+        cancel_msg.order_ref = 1
+        cancel_msg.shares = 25
+        processor.process_message(cancel_msg)
+
+        # Order should still exist
+        assert processor.lob is not None
+
+    def test_process_trade_message(self):
+        """Test processing trade message (hidden order)."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        # First add an order to create LOB
+        add_msg = AddOrderMessage()
+        add_msg.timestamp = 12345678
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        add_msg.display = b"Y"
+        processor.process_message(add_msg)
+
+        # Trade message for hidden order
+        trade_msg = TradeMessage()
+        trade_msg.timestamp = 12345679
+        trade_msg.order_ref = 999
+        trade_msg.side = b"S"
+        trade_msg.shares = 50
+        trade_msg.stock = b"AAPL  "
+        trade_msg.price = 150000
+        trade_msg.match_number = 123
+        processor.process_message(trade_msg)  # Should not affect LOB
+
+    def test_process_broken_trade_message(self):
+        """Test processing broken trade message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        broken_msg = BrokenTradeMessage()
+        broken_msg.timestamp = 12345679
+        broken_msg.match_number = 123
+        processor.process_message(broken_msg)  # Should not raise
+
+    def test_process_wrong_message_type(self):
+        """Test that wrong message type raises TypeError."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor("AAPL", book_date)
+
+        with pytest.raises(TypeError):
+            processor.process_message("not a message")  # type: ignore
+
+    def test_instrument_bytes(self):
+        """Test processor with bytes instrument."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH2MarketProcessor(b"AAPL  ", book_date)
+
+        message = AddOrderMessage()
+        message.timestamp = 12345678
+        message.order_ref = 1
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+        message.display = b"Y"
+
+        processor.process_message(message)
+
+        assert processor.lob is not None

--- a/tests/test_itch2_reader.py
+++ b/tests/test_itch2_reader.py
@@ -1,0 +1,179 @@
+"""Tests for ITCH 2.0 message reader functionality."""
+
+import gzip
+import tempfile
+import pytest
+from pathlib import Path
+
+from meatpy.itch2.itch2_message_reader import ITCH2MessageReader
+from meatpy.itch2.itch2_market_message import (
+    SystemEventMessage,
+    AddOrderMessage,
+    OrderExecutedMessage,
+)
+
+
+class TestITCH2MessageReader:
+    """Test the ITCH2MessageReader class."""
+
+    def create_test_data(self) -> bytes:
+        """Create test ITCH 2.0 data with a few messages."""
+        lines = [
+            b"12345678SO",  # System event - Start of messages
+            b"12345679A000000001B000100AAPL  0000150000Y",  # Add order
+            b"12345680E000000001000050000000001",  # Order executed
+        ]
+        return b"\n".join(lines) + b"\n"
+
+    def test_read_file_uncompressed(self):
+        """Test reading uncompressed ITCH 2.0 file."""
+        test_data = self.create_test_data()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            reader = ITCH2MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 3
+            assert isinstance(messages[0], SystemEventMessage)
+            assert isinstance(messages[1], AddOrderMessage)
+            assert isinstance(messages[2], OrderExecutedMessage)
+
+            # Check first message details
+            assert messages[0].event_code == b"O"
+            assert messages[0].timestamp == 12345678
+
+            # Check second message details
+            assert messages[1].side == b"B"
+            assert messages[1].shares == 100
+            assert messages[1].price == 150000
+
+    def test_read_file_gzip_compressed(self):
+        """Test reading gzip compressed ITCH 2.0 file."""
+        test_data = self.create_test_data()
+
+        with tempfile.NamedTemporaryFile(suffix=".gz", delete=False) as temp_file:
+            with gzip.open(temp_file.name, "wb") as gz_file:
+                gz_file.write(test_data)
+
+            reader = ITCH2MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 3
+            assert isinstance(messages[0], SystemEventMessage)
+            assert isinstance(messages[1], AddOrderMessage)
+
+    def test_context_manager_usage(self):
+        """Test using the reader as a context manager."""
+        test_data = self.create_test_data()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            messages = []
+            with ITCH2MessageReader(temp_file.name) as reader:
+                for message in reader:
+                    messages.append(message)
+
+            assert len(messages) == 3
+
+    def test_context_manager_without_file_path(self):
+        """Test context manager error when no file path provided."""
+        reader = ITCH2MessageReader()
+
+        with pytest.raises(ValueError, match="No file_path provided"):
+            with reader:
+                pass
+
+    def test_iterator_without_context_manager(self):
+        """Test iterator error when not used as context manager."""
+        reader = ITCH2MessageReader()
+
+        with pytest.raises(
+            RuntimeError, match="Reader must be used as a context manager"
+        ):
+            next(iter(reader))
+
+    def test_empty_file(self):
+        """Test reading an empty file."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            pass
+
+        reader = ITCH2MessageReader()
+        messages = list(reader.read_file(temp_file.name))
+
+        assert len(messages) == 0
+
+    def test_skip_empty_lines(self):
+        """Test that empty lines are skipped."""
+        lines = [
+            b"12345678SO",
+            b"",  # Empty line
+            b"12345679A000000001B000100AAPL  0000150000Y",
+            b"",  # Empty line
+        ]
+        test_data = b"\n".join(lines) + b"\n"
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            reader = ITCH2MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 2
+
+    def test_pathlib_path_support(self):
+        """Test that Path objects are supported."""
+        test_data = self.create_test_data()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            file_path = Path(temp_file.name)
+
+            reader = ITCH2MessageReader()
+            messages = list(reader.read_file(file_path))
+
+            assert len(messages) == 3
+
+    def test_large_file_handling(self):
+        """Test reading with many messages."""
+        lines = []
+        for i in range(100):
+            timestamp = 12345678 + i
+            lines.append(f"{timestamp:08d}SO".encode())
+
+        test_data = b"\n".join(lines) + b"\n"
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            reader = ITCH2MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 100
+            for i, msg in enumerate(messages):
+                assert msg.timestamp == 12345678 + i
+
+    def test_carriage_return_handling(self):
+        """Test handling of Windows-style line endings."""
+        lines = [
+            b"12345678SO",
+            b"12345679A000000001B000100AAPL  0000150000Y",
+        ]
+        test_data = b"\r\n".join(lines) + b"\r\n"
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            reader = ITCH2MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 2

--- a/tests/test_itch3_messages.py
+++ b/tests/test_itch3_messages.py
@@ -1,0 +1,537 @@
+"""Tests for ITCH 3.0 market message functionality."""
+
+import json
+import pytest
+
+from meatpy.itch3.itch3_market_message import (
+    ITCH3MarketMessage,
+    SecondsMessage,
+    MillisecondsMessage,
+    SystemEventMessage,
+    StockDirectoryMessage,
+    StockTradingActionMessage,
+    MarketParticipantPositionMessage,
+    AddOrderMessage,
+    AddOrderMPIDMessage,
+    OrderExecutedMessage,
+    OrderExecutedPriceMessage,
+    OrderCancelMessage,
+    OrderDeleteMessage,
+    TradeMessage,
+    CrossTradeMessage,
+    BrokenTradeMessage,
+    NoiiMessage,
+)
+
+
+class TestITCH3MarketMessage:
+    """Test the base ITCH3MarketMessage class."""
+
+    def test_from_bytes_unknown_type(self):
+        """Test handling of unknown message types."""
+        data = b"Z" + b"0" * 20
+        with pytest.raises(ValueError, match="Unknown message type"):
+            ITCH3MarketMessage.from_bytes(data)
+
+    def test_from_bytes_too_short(self):
+        """Test handling of message that is too short."""
+        data = b""
+        with pytest.raises(ValueError, match="Message too short"):
+            ITCH3MarketMessage.from_bytes(data)
+
+    def test_from_json_unknown_type(self):
+        """Test handling of unknown message type in JSON."""
+        json_str = json.dumps({"message_type": "Z"})
+        with pytest.raises(ValueError, match="Unknown message type"):
+            ITCH3MarketMessage.from_json(json_str)
+
+
+class TestSecondsMessage:
+    """Test SecondsMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: T + seconds(5) = 6 chars
+        data = b"T12345"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, SecondsMessage)
+        assert message.seconds == 12345
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = SecondsMessage()
+        message.seconds = 12345
+
+        data = message.to_bytes()
+
+        assert data == b"T12345"
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = SecondsMessage()
+        message.seconds = 54321
+
+        json_str = message.to_json()
+        new_message = ITCH3MarketMessage.from_json(json_str)
+
+        assert isinstance(new_message, SecondsMessage)
+        assert new_message.seconds == message.seconds
+
+
+class TestMillisecondsMessage:
+    """Test MillisecondsMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: M + milliseconds(3) = 4 chars
+        data = b"M123"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, MillisecondsMessage)
+        assert message.milliseconds == 123
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = MillisecondsMessage()
+        message.milliseconds = 456
+
+        data = message.to_bytes()
+
+        assert data == b"M456"
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = MillisecondsMessage()
+        message.milliseconds = 789
+
+        json_str = message.to_json()
+        new_message = ITCH3MarketMessage.from_json(json_str)
+
+        assert isinstance(new_message, MillisecondsMessage)
+        assert new_message.milliseconds == message.milliseconds
+
+
+class TestSystemEventMessage:
+    """Test SystemEventMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: S + event_code(1) = 2 chars
+        data = b"SO"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, SystemEventMessage)
+        assert message.event_code == b"O"
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = SystemEventMessage()
+        message.event_code = b"Q"
+
+        data = message.to_bytes()
+
+        assert data == b"SQ"
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = SystemEventMessage()
+        message.event_code = b"M"
+
+        json_str = message.to_json()
+        new_message = ITCH3MarketMessage.from_json(json_str)
+
+        assert isinstance(new_message, SystemEventMessage)
+        assert new_message.event_code == message.event_code
+
+
+class TestStockDirectoryMessage:
+    """Test StockDirectoryMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: R + stock(6) + market_category(1) + financial_status(1) + round_lot_size(6) + round_lots_only(1) = 16 chars
+        data = b"RAAPL  QN   100Y"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, StockDirectoryMessage)
+        assert message.stock == b"AAPL  "
+        assert message.market_category == b"Q"
+        assert message.financial_status == b"N"
+        assert message.round_lot_size == 100
+        assert message.round_lots_only == b"Y"
+
+    def test_from_bytes_with_spaces_in_lot_size(self):
+        """Test handling spaces in round lot size field."""
+        data = b"RAAPL  QN     1Y"  # Spaces before 1
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, StockDirectoryMessage)
+        assert message.round_lot_size == 1
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = StockDirectoryMessage()
+        message.stock = b"MSFT  "
+        message.market_category = b"G"
+        message.financial_status = b"D"
+        message.round_lot_size = 100
+        message.round_lots_only = b"N"
+
+        data = message.to_bytes()
+
+        assert data == b"RMSFT  GD   100N"
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = StockDirectoryMessage()
+        message.stock = b"GOOG  "
+        message.market_category = b"Q"
+        message.financial_status = b"N"
+        message.round_lot_size = 100
+        message.round_lots_only = b"Y"
+
+        json_str = message.to_json()
+        new_message = ITCH3MarketMessage.from_json(json_str)
+
+        assert isinstance(new_message, StockDirectoryMessage)
+        assert new_message.stock.decode().rstrip() == "GOOG"
+
+
+class TestAddOrderMessage:
+    """Test AddOrderMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: A + order_ref(9) + side(1) + shares(6) + stock(6) + price(10) = 33 chars
+        data = b"A000000001B000100AAPL  0000150000"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, AddOrderMessage)
+        assert message.order_ref == 1
+        assert message.side == b"B"
+        assert message.shares == 100
+        assert message.stock == b"AAPL  "
+        assert message.price == 150000
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = AddOrderMessage()
+        message.order_ref = 1
+        message.side = b"S"
+        message.shares = 200
+        message.stock = b"MSFT  "
+        message.price = 250000
+
+        data = message.to_bytes()
+
+        assert data == b"A        1S   200MSFT  0000250000"
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = AddOrderMessage()
+        message.order_ref = 999
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+
+        json_str = message.to_json()
+        new_message = ITCH3MarketMessage.from_json(json_str)
+
+        assert isinstance(new_message, AddOrderMessage)
+        assert new_message.order_ref == message.order_ref
+
+
+class TestAddOrderMPIDMessage:
+    """Test AddOrderMPIDMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: F + order_ref(9) + side(1) + shares(6) + stock(6) + price(10) + mpid(4) = 37 chars
+        data = b"F000000001B000100AAPL  0000150000ABCD"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, AddOrderMPIDMessage)
+        assert message.order_ref == 1
+        assert message.side == b"B"
+        assert message.shares == 100
+        assert message.stock == b"AAPL  "
+        assert message.price == 150000
+        assert message.mpid == b"ABCD"
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = AddOrderMPIDMessage()
+        message.order_ref = 1
+        message.side = b"S"
+        message.shares = 200
+        message.stock = b"MSFT  "
+        message.price = 250000
+        message.mpid = b"WXYZ"
+
+        data = message.to_bytes()
+
+        assert data == b"F        1S   200MSFT  0000250000WXYZ"
+
+
+class TestOrderExecutedMessage:
+    """Test OrderExecutedMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: E + order_ref(9) + shares(6) + match_number(9) = 25 chars
+        data = b"E000000001000050000000123"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, OrderExecutedMessage)
+        assert message.order_ref == 1
+        assert message.shares == 50
+        assert message.match_number == 123
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = OrderExecutedMessage()
+        message.order_ref = 1
+        message.shares = 50
+        message.match_number = 123
+
+        data = message.to_bytes()
+
+        assert data == b"E        1    50      123"
+
+
+class TestOrderExecutedPriceMessage:
+    """Test OrderExecutedPriceMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: C + order_ref(9) + shares(6) + match_number(9) + printable(1) + price(10) = 36 chars
+        data = b"C000000001000050000000123Y0000150000"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, OrderExecutedPriceMessage)
+        assert message.order_ref == 1
+        assert message.shares == 50
+        assert message.match_number == 123
+        assert message.printable == b"Y"
+        assert message.price == 150000
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = OrderExecutedPriceMessage()
+        message.order_ref = 1
+        message.shares = 50
+        message.match_number = 123
+        message.printable = b"Y"
+        message.price = 150000
+
+        data = message.to_bytes()
+
+        assert data == b"C        1    50      123Y0000150000"
+
+
+class TestOrderCancelMessage:
+    """Test OrderCancelMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: X + order_ref(9) + shares(6) = 16 chars
+        data = b"X000000001000025"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, OrderCancelMessage)
+        assert message.order_ref == 1
+        assert message.shares == 25
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = OrderCancelMessage()
+        message.order_ref = 1
+        message.shares = 25
+
+        data = message.to_bytes()
+
+        assert data == b"X        1    25"
+
+
+class TestOrderDeleteMessage:
+    """Test OrderDeleteMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: D + order_ref(9) = 10 chars
+        data = b"D000000001"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, OrderDeleteMessage)
+        assert message.order_ref == 1
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = OrderDeleteMessage()
+        message.order_ref = 999
+
+        data = message.to_bytes()
+
+        assert data == b"D      999"
+
+
+class TestTradeMessage:
+    """Test TradeMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: P + order_ref(9) + side(1) + shares(6) + stock(6) + price(10) + match_number(9) = 42 chars
+        data = b"P000000001S000100AAPL  0000150000000000123"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, TradeMessage)
+        assert message.order_ref == 1
+        assert message.side == b"S"
+        assert message.shares == 100
+        assert message.stock == b"AAPL  "
+        assert message.price == 150000
+        assert message.match_number == 123
+
+
+class TestCrossTradeMessage:
+    """Test CrossTradeMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: Q + shares(9) + stock(6) + price(10) + match_number(9) + cross_type(1) = 36 chars
+        data = b"Q000001000AAPL  0000150000000000123O"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, CrossTradeMessage)
+        assert message.shares == 1000
+        assert message.stock == b"AAPL  "
+        assert message.price == 150000
+        assert message.match_number == 123
+        assert message.cross_type == b"O"
+
+
+class TestBrokenTradeMessage:
+    """Test BrokenTradeMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: B + match_number(9) = 10 chars
+        data = b"B000000123"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, BrokenTradeMessage)
+        assert message.match_number == 123
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = BrokenTradeMessage()
+        message.match_number = 456
+
+        data = message.to_bytes()
+
+        assert data == b"B      456"
+
+
+class TestNoiiMessage:
+    """Test NoiiMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: I + paired_shares(9) + imbalance_shares(9) + imbalance_direction(1)
+        #         + stock(6) + far_price(10) + near_price(10) + ref_price(10) + cross_type(2) = 58 chars
+        data = b"I000010000000005000BAAPL  000015000000001500000000150000OC"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, NoiiMessage)
+        assert message.paired_shares == 10000
+        assert message.imbalance_shares == 5000
+        assert message.imbalance_direction == b"B"
+        assert message.stock == b"AAPL  "
+        assert message.far_price == 150000
+        assert message.near_price == 150000
+        assert message.ref_price == 150000
+        assert message.cross_type == b"OC"
+
+
+class TestStockTradingActionMessage:
+    """Test StockTradingActionMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: H + stock(6) + state(1) + reserved(5) = 13 chars
+        data = b"HAAPL  T     "
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, StockTradingActionMessage)
+        assert message.stock == b"AAPL  "
+        assert message.state == b"T"
+
+
+class TestMarketParticipantPositionMessage:
+    """Test MarketParticipantPositionMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: L + stock(6) + mpid(4) + primary_mm(1) + mode(1) + state(1) = 14 chars
+        data = b"LAAPL  ABCDYNA"
+
+        message = ITCH3MarketMessage.from_bytes(data)
+
+        assert isinstance(message, MarketParticipantPositionMessage)
+        assert message.stock == b"AAPL  "
+        assert message.mpid == b"ABCD"
+        assert message.primary_mm == b"Y"
+        assert message.mode == b"N"
+        assert message.state == b"A"
+
+
+class TestMessageTypeMappings:
+    """Test that all message types are properly mapped."""
+
+    def test_all_message_types_registered(self):
+        """Verify all message types can be parsed."""
+        test_cases = [
+            (b"T12345", SecondsMessage),
+            (b"M123", MillisecondsMessage),
+            (b"SO", SystemEventMessage),
+            (b"RAAPL  QN   100Y", StockDirectoryMessage),
+            (b"HAAPL  T     ", StockTradingActionMessage),
+            (b"LAAPL  ABCDYNA", MarketParticipantPositionMessage),
+            (b"A000000001B000100AAPL  0000150000", AddOrderMessage),
+            (b"F000000001B000100AAPL  0000150000ABCD", AddOrderMPIDMessage),
+            (b"E000000001000050000000123", OrderExecutedMessage),
+            (b"C000000001000050000000123Y0000150000", OrderExecutedPriceMessage),
+            (b"X000000001000025", OrderCancelMessage),
+            (b"D000000001", OrderDeleteMessage),
+            (b"P000000001S000100AAPL  0000150000000000123", TradeMessage),
+            (b"Q000001000AAPL  0000150000000000123O", CrossTradeMessage),
+            (b"B000000123", BrokenTradeMessage),
+            (
+                b"I000010000000005000BAAPL  000015000000001500000000150000OC",
+                NoiiMessage,
+            ),
+        ]
+
+        for data, expected_class in test_cases:
+            message = ITCH3MarketMessage.from_bytes(data)
+            assert isinstance(message, expected_class), (
+                f"Failed for {expected_class.__name__}"
+            )

--- a/tests/test_itch3_processor.py
+++ b/tests/test_itch3_processor.py
@@ -1,0 +1,467 @@
+"""Tests for ITCH 3.0 market processor functionality."""
+
+import datetime
+import pytest
+
+from meatpy.itch3.itch3_market_processor import (
+    ITCH3MarketProcessor,
+    InvalidBuySellIndicatorError,
+)
+from meatpy.itch3.itch3_market_message import (
+    SecondsMessage,
+    MillisecondsMessage,
+    SystemEventMessage,
+    StockDirectoryMessage,
+    StockTradingActionMessage,
+    AddOrderMessage,
+    AddOrderMPIDMessage,
+    OrderExecutedMessage,
+    OrderExecutedPriceMessage,
+    OrderCancelMessage,
+    OrderDeleteMessage,
+    TradeMessage,
+    CrossTradeMessage,
+    BrokenTradeMessage,
+    NoiiMessage,
+)
+from meatpy.lob import OrderType
+from meatpy.trading_status import (
+    TradeTradingStatus,
+    PostTradeTradingStatus,
+    HaltedTradingStatus,
+    QuoteOnlyTradingStatus,
+)
+
+
+class TestITCH3MarketProcessor:
+    """Test the ITCH3MarketProcessor class."""
+
+    def test_init(self):
+        """Test processor initialization."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        assert processor.instrument == "AAPL"
+        assert processor.book_date == book_date
+        assert processor.lob is None
+        assert processor.current_second == 0
+        assert processor.current_millisecond == 0
+
+    def test_adjust_timestamp(self):
+        """Test timestamp adjustment from seconds + milliseconds."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        processor.current_second = 36000  # 10 hours
+        processor.current_millisecond = 500
+
+        timestamp = processor.adjust_timestamp()
+
+        # Should be book_date + 36000500 milliseconds
+        # Timestamp extends datetime, so compare directly
+        expected = book_date + datetime.timedelta(milliseconds=36000500)
+        assert timestamp.year == expected.year
+        assert timestamp.month == expected.month
+        assert timestamp.day == expected.day
+        assert timestamp.hour == expected.hour
+        assert timestamp.minute == expected.minute
+        assert timestamp.second == expected.second
+
+    def test_process_seconds_message(self):
+        """Test processing seconds message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = SecondsMessage()
+        message.seconds = 36000
+
+        processor.process_message(message)
+
+        assert processor.current_second == 36000
+
+    def test_process_milliseconds_message(self):
+        """Test processing milliseconds message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = MillisecondsMessage()
+        message.milliseconds = 500
+
+        processor.process_message(message)
+
+        assert processor.current_millisecond == 500
+
+    def test_process_system_event_start_messages(self):
+        """Test processing system event message - start of messages."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = SystemEventMessage()
+        message.event_code = b"O"
+
+        processor.process_message(message)
+
+        assert processor.system_status == b"O"
+        assert processor.trading_status == PostTradeTradingStatus
+
+    def test_process_system_event_start_market(self):
+        """Test processing system event message - start of market hours."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        # Start system first
+        sys_msg = SystemEventMessage()
+        sys_msg.event_code = b"Q"
+        processor.process_message(sys_msg)
+
+        assert processor.system_status == b"Q"
+
+    def test_process_stock_trading_action(self):
+        """Test processing stock trading action message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        # Start system first
+        sys_msg = SystemEventMessage()
+        sys_msg.event_code = b"Q"
+        processor.process_message(sys_msg)
+
+        # Then set stock trading status
+        action_msg = StockTradingActionMessage()
+        action_msg.stock = b"AAPL  "
+        action_msg.state = b"T"
+        action_msg.reserved = b"     "
+        processor.process_message(action_msg)
+
+        assert processor.stock_status == b"T"
+        assert processor.trading_status == TradeTradingStatus
+
+    def test_process_stock_trading_action_halted(self):
+        """Test processing stock trading action message - halted."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        # Start market
+        sys_msg = SystemEventMessage()
+        sys_msg.event_code = b"Q"
+        processor.process_message(sys_msg)
+
+        # Set stock as halted
+        action_msg = StockTradingActionMessage()
+        action_msg.stock = b"AAPL  "
+        action_msg.state = b"H"
+        action_msg.reserved = b"     "
+        processor.process_message(action_msg)
+
+        assert processor.stock_status == b"H"
+        assert processor.trading_status == HaltedTradingStatus
+
+    def test_process_stock_trading_action_quote_only(self):
+        """Test processing stock trading action message - quote only."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        # Start market
+        sys_msg = SystemEventMessage()
+        sys_msg.event_code = b"Q"
+        processor.process_message(sys_msg)
+
+        # Set stock as quote only
+        action_msg = StockTradingActionMessage()
+        action_msg.stock = b"AAPL  "
+        action_msg.state = b"Q"
+        action_msg.reserved = b"     "
+        processor.process_message(action_msg)
+
+        assert processor.stock_status == b"Q"
+        assert processor.trading_status == QuoteOnlyTradingStatus
+
+    def test_process_stock_trading_action_different_stock(self):
+        """Test that trading actions for different stocks are ignored."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        action_msg = StockTradingActionMessage()
+        action_msg.stock = b"MSFT  "
+        action_msg.state = b"T"
+        action_msg.reserved = b"     "
+        processor.process_message(action_msg)
+
+        # Stock status should remain empty
+        assert processor.stock_status == b""
+
+    def test_process_stock_directory(self):
+        """Test processing stock directory message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = StockDirectoryMessage()
+        message.stock = b"AAPL  "
+        message.market_category = b"Q"
+        message.financial_status = b"N"
+        message.round_lot_size = 100
+        message.round_lots_only = b"Y"
+
+        # Should not raise
+        processor.process_message(message)
+
+    def test_process_add_order_buy(self):
+        """Test processing add order message - buy side."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMessage()
+        message.order_ref = 1
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+
+        processor.process_message(message)
+
+        assert processor.lob is not None
+        order_type = processor.lob.find_order_type(1)
+        assert order_type == OrderType.BID
+
+    def test_process_add_order_sell(self):
+        """Test processing add order message - sell side."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMessage()
+        message.order_ref = 2
+        message.side = b"S"
+        message.shares = 200
+        message.stock = b"AAPL  "
+        message.price = 151000
+
+        processor.process_message(message)
+
+        assert processor.lob is not None
+        order_type = processor.lob.find_order_type(2)
+        assert order_type == OrderType.ASK
+
+    def test_process_add_order_invalid_side(self):
+        """Test processing add order with invalid side."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMessage()
+        message.order_ref = 1
+        message.side = b"X"  # Invalid side
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+
+        with pytest.raises(InvalidBuySellIndicatorError):
+            processor.process_message(message)
+
+    def test_process_add_order_different_instrument(self):
+        """Test that orders for different instruments are ignored."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMessage()
+        message.order_ref = 1
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"MSFT  "
+        message.price = 150000
+
+        processor.process_message(message)
+
+        assert processor.lob is None
+
+    def test_process_add_order_mpid(self):
+        """Test processing add order with MPID message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMPIDMessage()
+        message.order_ref = 1
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+        message.mpid = b"ABCD"
+
+        processor.process_message(message)
+
+        assert processor.lob is not None
+        order_type = processor.lob.find_order_type(1)
+        assert order_type == OrderType.BID
+
+    def test_process_add_order_mpid_invalid_side(self):
+        """Test processing add order MPID with invalid side."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMPIDMessage()
+        message.order_ref = 1
+        message.side = b"X"  # Invalid side
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+        message.mpid = b"ABCD"
+
+        with pytest.raises(InvalidBuySellIndicatorError):
+            processor.process_message(message)
+
+    def test_process_order_executed(self):
+        """Test processing order executed message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        # First add an order
+        add_msg = AddOrderMessage()
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        processor.process_message(add_msg)
+
+        # Then execute part of it
+        exec_msg = OrderExecutedMessage()
+        exec_msg.order_ref = 1
+        exec_msg.shares = 50
+        exec_msg.match_number = 123
+        processor.process_message(exec_msg)
+
+    def test_process_order_executed_price(self):
+        """Test processing order executed with price message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        # First add an order
+        add_msg = AddOrderMessage()
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        processor.process_message(add_msg)
+
+        # Then execute with different price
+        exec_msg = OrderExecutedPriceMessage()
+        exec_msg.order_ref = 1
+        exec_msg.shares = 50
+        exec_msg.match_number = 123
+        exec_msg.printable = b"Y"
+        exec_msg.price = 149500
+        processor.process_message(exec_msg)
+
+    def test_process_order_cancel(self):
+        """Test processing order cancel message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        # First add an order
+        add_msg = AddOrderMessage()
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        processor.process_message(add_msg)
+
+        # Then cancel part of it
+        cancel_msg = OrderCancelMessage()
+        cancel_msg.order_ref = 1
+        cancel_msg.shares = 25
+        processor.process_message(cancel_msg)
+
+    def test_process_order_delete(self):
+        """Test processing order delete message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        # First add an order
+        add_msg = AddOrderMessage()
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        processor.process_message(add_msg)
+
+        # Then delete it
+        delete_msg = OrderDeleteMessage()
+        delete_msg.order_ref = 1
+        processor.process_message(delete_msg)
+
+    def test_process_trade_message(self):
+        """Test processing trade message (hidden order)."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = TradeMessage()
+        message.order_ref = 999
+        message.side = b"S"
+        message.shares = 50
+        message.stock = b"AAPL  "
+        message.price = 150000
+        message.match_number = 123
+        processor.process_message(message)  # Should not raise
+
+    def test_process_cross_trade_message(self):
+        """Test processing cross trade message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = CrossTradeMessage()
+        message.shares = 1000
+        message.stock = b"AAPL  "
+        message.price = 150000
+        message.match_number = 123
+        message.cross_type = b"O"
+        processor.process_message(message)  # Should not raise
+
+    def test_process_broken_trade_message(self):
+        """Test processing broken trade message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = BrokenTradeMessage()
+        message.match_number = 123
+        processor.process_message(message)  # Should not raise
+
+    def test_process_noii_message(self):
+        """Test processing NOII message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        message = NoiiMessage()
+        message.paired_shares = 10000
+        message.imbalance_shares = 5000
+        message.imbalance_direction = b"B"
+        message.stock = b"AAPL  "
+        message.far_price = 150000
+        message.near_price = 150000
+        message.ref_price = 150000
+        message.cross_type = b"OC"
+        processor.process_message(message)  # Should not raise
+
+    def test_process_wrong_message_type(self):
+        """Test that wrong message type raises TypeError."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor("AAPL", book_date)
+
+        with pytest.raises(TypeError):
+            processor.process_message("not a message")  # type: ignore
+
+    def test_instrument_bytes(self):
+        """Test processor with bytes instrument."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH3MarketProcessor(b"AAPL  ", book_date)
+
+        message = AddOrderMessage()
+        message.order_ref = 1
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+
+        processor.process_message(message)
+
+        assert processor.lob is not None

--- a/tests/test_itch3_reader.py
+++ b/tests/test_itch3_reader.py
@@ -1,0 +1,176 @@
+"""Tests for ITCH 3.0 message reader functionality."""
+
+import gzip
+import tempfile
+import pytest
+from pathlib import Path
+
+from meatpy.itch3.itch3_message_reader import ITCH3MessageReader
+from meatpy.itch3.itch3_market_message import (
+    SecondsMessage,
+    MillisecondsMessage,
+    SystemEventMessage,
+    AddOrderMessage,
+)
+
+
+class TestITCH3MessageReader:
+    """Test the ITCH3MessageReader class."""
+
+    def create_test_data(self) -> bytes:
+        """Create test ITCH 3.0 data with a few messages."""
+        lines = [
+            b"T12345",  # Seconds message
+            b"M123",  # Milliseconds message
+            b"SO",  # System event - Start of messages
+            b"A000000001B000100AAPL  0000150000",  # Add order
+        ]
+        return b"\n".join(lines) + b"\n"
+
+    def test_read_file_uncompressed(self):
+        """Test reading uncompressed ITCH 3.0 file."""
+        test_data = self.create_test_data()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            reader = ITCH3MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 4
+            assert isinstance(messages[0], SecondsMessage)
+            assert isinstance(messages[1], MillisecondsMessage)
+            assert isinstance(messages[2], SystemEventMessage)
+            assert isinstance(messages[3], AddOrderMessage)
+
+            # Check message details
+            assert messages[0].seconds == 12345
+            assert messages[1].milliseconds == 123
+            assert messages[2].event_code == b"O"
+            assert messages[3].order_ref == 1
+
+    def test_read_file_gzip_compressed(self):
+        """Test reading gzip compressed ITCH 3.0 file."""
+        test_data = self.create_test_data()
+
+        with tempfile.NamedTemporaryFile(suffix=".gz", delete=False) as temp_file:
+            with gzip.open(temp_file.name, "wb") as gz_file:
+                gz_file.write(test_data)
+
+            reader = ITCH3MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 4
+            assert isinstance(messages[0], SecondsMessage)
+
+    def test_context_manager_usage(self):
+        """Test using the reader as a context manager."""
+        test_data = self.create_test_data()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            messages = []
+            with ITCH3MessageReader(temp_file.name) as reader:
+                for message in reader:
+                    messages.append(message)
+
+            assert len(messages) == 4
+
+    def test_context_manager_without_file_path(self):
+        """Test context manager error when no file path provided."""
+        reader = ITCH3MessageReader()
+
+        with pytest.raises(ValueError, match="No file_path provided"):
+            with reader:
+                pass
+
+    def test_iterator_without_context_manager(self):
+        """Test iterator error when not used as context manager."""
+        reader = ITCH3MessageReader()
+
+        with pytest.raises(
+            RuntimeError, match="Reader must be used as a context manager"
+        ):
+            next(iter(reader))
+
+    def test_empty_file(self):
+        """Test reading an empty file."""
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            pass
+
+        reader = ITCH3MessageReader()
+        messages = list(reader.read_file(temp_file.name))
+
+        assert len(messages) == 0
+
+    def test_skip_empty_lines(self):
+        """Test that empty lines are skipped."""
+        lines = [
+            b"T12345",
+            b"",  # Empty line
+            b"M123",
+            b"",  # Empty line
+        ]
+        test_data = b"\n".join(lines) + b"\n"
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            reader = ITCH3MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 2
+
+    def test_pathlib_path_support(self):
+        """Test that Path objects are supported."""
+        test_data = self.create_test_data()
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            file_path = Path(temp_file.name)
+
+            reader = ITCH3MessageReader()
+            messages = list(reader.read_file(file_path))
+
+            assert len(messages) == 4
+
+    def test_large_file_handling(self):
+        """Test reading with many messages."""
+        lines = []
+        for i in range(100):
+            lines.append(f"T{i:05d}".encode())
+            lines.append(f"M{i % 1000:03d}".encode())
+
+        test_data = b"\n".join(lines) + b"\n"
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            reader = ITCH3MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 200
+
+    def test_carriage_return_handling(self):
+        """Test handling of Windows-style line endings."""
+        lines = [
+            b"T12345",
+            b"M123",
+        ]
+        test_data = b"\r\n".join(lines) + b"\r\n"
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            reader = ITCH3MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 2

--- a/tests/test_itch4_messages.py
+++ b/tests/test_itch4_messages.py
@@ -1,0 +1,533 @@
+"""Tests for ITCH 4.0 market message functionality."""
+
+import json
+import struct
+import pytest
+
+from meatpy.itch4.itch4_market_message import (
+    ITCH4MarketMessage,
+    SecondsMessage,
+    SystemEventMessage,
+    StockDirectoryMessage,
+    StockTradingActionMessage,
+    MarketParticipantPositionMessage,
+    AddOrderMessage,
+    AddOrderMPIDMessage,
+    OrderExecutedMessage,
+    OrderExecutedPriceMessage,
+    OrderCancelMessage,
+    OrderDeleteMessage,
+    OrderReplaceMessage,
+    TradeMessage,
+    CrossTradeMessage,
+    BrokenTradeMessage,
+    NoiiMessage,
+)
+from meatpy.message_reader import UnknownMessageTypeError
+
+
+class TestITCH4MarketMessage:
+    """Test the base ITCH4MarketMessage class."""
+
+    def test_from_bytes_empty_data(self):
+        """Test handling of empty data."""
+        with pytest.raises(ValueError, match="Empty message data"):
+            ITCH4MarketMessage.from_bytes(b"")
+
+    def test_from_bytes_unknown_type(self):
+        """Test handling of unknown message types."""
+        data = b"Z" + b"\x00" * 20
+        with pytest.raises(UnknownMessageTypeError):
+            ITCH4MarketMessage.from_bytes(data)
+
+    def test_from_json_unknown_type(self):
+        """Test handling of unknown message type in JSON."""
+        json_str = json.dumps({"type": "Z", "timestamp": 12345})
+        with pytest.raises(UnknownMessageTypeError):
+            ITCH4MarketMessage.from_json(json_str)
+
+
+class TestSecondsMessage:
+    """Test SecondsMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: T(1) + seconds(4) = 5 bytes
+        data = struct.pack("!cI", b"T", 12345)
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, SecondsMessage)
+        assert message.seconds == 12345
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = SecondsMessage()
+        message.seconds = 12345
+
+        data = message.to_bytes()
+
+        expected = struct.pack("!cI", b"T", 12345)
+        assert data == expected
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = SecondsMessage()
+        message.seconds = 54321
+
+        json_str = message.to_json()
+        new_message = ITCH4MarketMessage.from_json(json_str)
+
+        assert isinstance(new_message, SecondsMessage)
+        assert new_message.seconds == message.seconds
+
+
+class TestSystemEventMessage:
+    """Test SystemEventMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: S(1) + timestamp(4) + event_code(1) = 6 bytes
+        data = struct.pack("!cIc", b"S", 12345, b"O")
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, SystemEventMessage)
+        assert message.timestamp == 12345
+        assert message.event_code == b"O"
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = SystemEventMessage()
+        message.timestamp = 12345
+        message.event_code = b"O"
+
+        data = message.to_bytes()
+
+        expected = struct.pack("!cIc", b"S", 12345, b"O")
+        assert data == expected
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = SystemEventMessage()
+        message.timestamp = 12345
+        message.event_code = b"Q"
+
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["timestamp"] == 12345
+        assert data["event_code"] == "Q"
+
+        new_message = ITCH4MarketMessage.from_json(json_str)
+        assert isinstance(new_message, SystemEventMessage)
+        assert new_message.event_code == message.event_code
+
+
+class TestStockDirectoryMessage:
+    """Test StockDirectoryMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: R(1) + timestamp(4) + stock(6) + market_category(1) + financial_status(1)
+        #         + round_lot_size(4) + round_lots_only(1) = 18 bytes
+        data = struct.pack("!cI6sccIc", b"R", 12345, b"AAPL  ", b"Q", b"N", 100, b"Y")
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, StockDirectoryMessage)
+        assert message.timestamp == 12345
+        assert message.stock == b"AAPL  "
+        assert message.category == b"Q"
+        assert message.status == b"N"
+        assert message.lotsize == 100
+        assert message.lotsonly == b"Y"
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = StockDirectoryMessage()
+        message.timestamp = 12345
+        message.stock = b"MSFT  "
+        message.category = b"G"
+        message.status = b"D"
+        message.lotsize = 100
+        message.lotsonly = b"N"
+
+        data = message.to_bytes()
+
+        expected = struct.pack(
+            "!cI6sccIc", b"R", 12345, b"MSFT  ", b"G", b"D", 100, b"N"
+        )
+        assert data == expected
+
+
+class TestAddOrderMessage:
+    """Test AddOrderMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: A(1) + timestamp(4) + order_ref(8) + side(1) + shares(4) + stock(6) + price(4) = 28 bytes
+        data = struct.pack("!cIQcI6sI", b"A", 12345, 999, b"B", 100, b"AAPL  ", 150000)
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, AddOrderMessage)
+        assert message.timestamp == 12345
+        assert message.order_ref == 999
+        assert message.side == b"B"
+        assert message.shares == 100
+        assert message.stock == b"AAPL  "
+        assert message.price == 150000
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = AddOrderMessage()
+        message.timestamp = 12345
+        message.order_ref = 999
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+
+        data = message.to_bytes()
+
+        expected = struct.pack(
+            "!cIQcI6sI", b"A", 12345, 999, b"B", 100, b"AAPL  ", 150000
+        )
+        assert data == expected
+
+    def test_json_roundtrip(self):
+        """Test JSON serialization and deserialization."""
+        message = AddOrderMessage()
+        message.timestamp = 12345
+        message.order_ref = 999
+        message.side = b"S"
+        message.shares = 200
+        message.stock = b"MSFT  "
+        message.price = 250000
+
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["order_ref"] == 999
+        assert data["side"] == "S"
+        assert data["stock"] == "MSFT"
+
+        new_message = ITCH4MarketMessage.from_json(json_str)
+        assert isinstance(new_message, AddOrderMessage)
+        assert new_message.order_ref == message.order_ref
+
+
+class TestAddOrderMPIDMessage:
+    """Test AddOrderMPIDMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: F(1) + timestamp(4) + order_ref(8) + side(1) + shares(4) + stock(6) + price(4) + mpid(4) = 32 bytes
+        data = struct.pack(
+            "!cIQcI6sI4s", b"F", 12345, 999, b"B", 100, b"AAPL  ", 150000, b"ABCD"
+        )
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, AddOrderMPIDMessage)
+        assert message.order_ref == 999
+        assert message.mpid == b"ABCD"
+
+
+class TestOrderExecutedMessage:
+    """Test OrderExecutedMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: E(1) + timestamp(4) + order_ref(8) + shares(4) + match_number(8) = 25 bytes
+        data = struct.pack("!cIQIQ", b"E", 12345, 999, 50, 12345)
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, OrderExecutedMessage)
+        assert message.timestamp == 12345
+        assert message.order_ref == 999
+        assert message.shares == 50
+        assert message.match_number == 12345
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = OrderExecutedMessage()
+        message.timestamp = 12345
+        message.order_ref = 999
+        message.shares = 50
+        message.match_number = 12345
+
+        data = message.to_bytes()
+
+        expected = struct.pack("!cIQIQ", b"E", 12345, 999, 50, 12345)
+        assert data == expected
+
+
+class TestOrderExecutedPriceMessage:
+    """Test OrderExecutedPriceMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: C(1) + timestamp(4) + order_ref(8) + shares(4) + match_number(8) + printable(1) + price(4) = 30 bytes
+        data = struct.pack("!cIQIQcI", b"C", 12345, 999, 50, 12345, b"Y", 150000)
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, OrderExecutedPriceMessage)
+        assert message.order_ref == 999
+        assert message.printable == b"Y"
+        assert message.price == 150000
+
+
+class TestOrderCancelMessage:
+    """Test OrderCancelMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: X(1) + timestamp(4) + order_ref(8) + shares(4) = 17 bytes
+        data = struct.pack("!cIQI", b"X", 12345, 999, 25)
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, OrderCancelMessage)
+        assert message.timestamp == 12345
+        assert message.order_ref == 999
+        assert message.shares == 25
+
+
+class TestOrderDeleteMessage:
+    """Test OrderDeleteMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: D(1) + timestamp(4) + order_ref(8) = 13 bytes
+        data = struct.pack("!cIQ", b"D", 12345, 999)
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, OrderDeleteMessage)
+        assert message.timestamp == 12345
+        assert message.order_ref == 999
+
+
+class TestOrderReplaceMessage:
+    """Test OrderReplaceMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: U(1) + timestamp(4) + original_ref(8) + new_ref(8) + shares(4) + price(4) = 29 bytes
+        data = struct.pack("!cIQQII", b"U", 12345, 999, 1000, 100, 150000)
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, OrderReplaceMessage)
+        assert message.timestamp == 12345
+        assert message.original_ref == 999
+        assert message.new_ref == 1000
+        assert message.shares == 100
+        assert message.price == 150000
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = OrderReplaceMessage()
+        message.timestamp = 12345
+        message.original_ref = 999
+        message.new_ref = 1000
+        message.shares = 100
+        message.price = 150000
+
+        data = message.to_bytes()
+
+        expected = struct.pack("!cIQQII", b"U", 12345, 999, 1000, 100, 150000)
+        assert data == expected
+
+
+class TestTradeMessage:
+    """Test TradeMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: P(1) + timestamp(4) + order_ref(8) + side(1) + shares(4) + stock(6) + price(4) + match_number(8) = 36 bytes
+        data = struct.pack(
+            "!cIQcI6sIQ", b"P", 12345, 999, b"S", 100, b"AAPL  ", 150000, 12345
+        )
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, TradeMessage)
+        assert message.order_ref == 999
+        assert message.side == b"S"
+        assert message.shares == 100
+        assert message.price == 150000
+
+
+class TestCrossTradeMessage:
+    """Test CrossTradeMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: Q(1) + timestamp(4) + shares(8) + stock(6) + price(4) + match_number(8) + cross_type(1) = 32 bytes
+        data = struct.pack(
+            "!cIQ6sIQc", b"Q", 12345, 1000, b"AAPL  ", 150000, 12345, b"O"
+        )
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, CrossTradeMessage)
+        assert message.shares == 1000
+        assert message.cross_type == b"O"
+
+
+class TestBrokenTradeMessage:
+    """Test BrokenTradeMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: B(1) + timestamp(4) + match_number(8) = 13 bytes
+        data = struct.pack("!cIQ", b"B", 12345, 12345)
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, BrokenTradeMessage)
+        assert message.timestamp == 12345
+        assert message.match_number == 12345
+
+
+class TestNoiiMessage:
+    """Test NoiiMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: I(1) + timestamp(4) + paired_shares(8) + imbalance_shares(8) + imbalance_direction(1)
+        #         + stock(6) + far_price(4) + near_price(4) + current_ref_price(4) + cross_type(1) + price_var(1) = 42 bytes
+        data = struct.pack(
+            "!cIQQc6sIIIcc",
+            b"I",
+            12345,
+            10000,
+            5000,
+            b"B",
+            b"AAPL  ",
+            150000,
+            150000,
+            150000,
+            b"O",
+            b" ",
+        )
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, NoiiMessage)
+        assert message.paired_shares == 10000
+        assert message.imbalance_shares == 5000
+        assert message.imbalance_direction == b"B"
+
+
+class TestStockTradingActionMessage:
+    """Test StockTradingActionMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: H(1) + timestamp(4) + stock(6) + state(1) + reserved(5) = 17 bytes
+        data = struct.pack("!cI6sc5s", b"H", 12345, b"AAPL  ", b"T", b"     ")
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, StockTradingActionMessage)
+        assert message.stock == b"AAPL  "
+        assert message.state == b"T"
+
+
+class TestMarketParticipantPositionMessage:
+    """Test MarketParticipantPositionMessage functionality."""
+
+    def test_from_bytes_data(self):
+        """Test creating message from bytes."""
+        # Format: L(1) + timestamp(4) + mpid(4) + stock(6) + primary(1) + mode(1) + state(1) = 18 bytes
+        data = struct.pack(
+            "!cI4s6sccc", b"L", 12345, b"ABCD", b"AAPL  ", b"Y", b"N", b"A"
+        )
+
+        message = ITCH4MarketMessage.from_bytes(data)
+
+        assert isinstance(message, MarketParticipantPositionMessage)
+        assert message.mpid == b"ABCD"
+        assert message.stock == b"AAPL  "
+        assert message.primary == b"Y"
+
+
+class TestMessageTypeMappings:
+    """Test that all message types are properly mapped."""
+
+    def test_all_message_types(self):
+        """Verify all message types can be parsed."""
+        test_cases = [
+            (struct.pack("!cI", b"T", 12345), SecondsMessage),
+            (struct.pack("!cIc", b"S", 12345, b"O"), SystemEventMessage),
+            (
+                struct.pack("!cI6sccIc", b"R", 12345, b"AAPL  ", b"Q", b"N", 100, b"Y"),
+                StockDirectoryMessage,
+            ),
+            (
+                struct.pack("!cI6sc5s", b"H", 12345, b"AAPL  ", b"T", b"     "),
+                StockTradingActionMessage,
+            ),
+            (
+                struct.pack(
+                    "!cI4s6sccc", b"L", 12345, b"ABCD", b"AAPL  ", b"Y", b"N", b"A"
+                ),
+                MarketParticipantPositionMessage,
+            ),
+            (
+                struct.pack(
+                    "!cIQcI6sI", b"A", 12345, 999, b"B", 100, b"AAPL  ", 150000
+                ),
+                AddOrderMessage,
+            ),
+            (
+                struct.pack(
+                    "!cIQcI6sI4s",
+                    b"F",
+                    12345,
+                    999,
+                    b"B",
+                    100,
+                    b"AAPL  ",
+                    150000,
+                    b"ABCD",
+                ),
+                AddOrderMPIDMessage,
+            ),
+            (struct.pack("!cIQIQ", b"E", 12345, 999, 50, 12345), OrderExecutedMessage),
+            (
+                struct.pack("!cIQIQcI", b"C", 12345, 999, 50, 12345, b"Y", 150000),
+                OrderExecutedPriceMessage,
+            ),
+            (struct.pack("!cIQI", b"X", 12345, 999, 25), OrderCancelMessage),
+            (struct.pack("!cIQ", b"D", 12345, 999), OrderDeleteMessage),
+            (
+                struct.pack("!cIQQII", b"U", 12345, 999, 1000, 100, 150000),
+                OrderReplaceMessage,
+            ),
+            (
+                struct.pack(
+                    "!cIQcI6sIQ", b"P", 12345, 999, b"S", 100, b"AAPL  ", 150000, 12345
+                ),
+                TradeMessage,
+            ),
+            (
+                struct.pack(
+                    "!cIQ6sIQc", b"Q", 12345, 1000, b"AAPL  ", 150000, 12345, b"O"
+                ),
+                CrossTradeMessage,
+            ),
+            (struct.pack("!cIQ", b"B", 12345, 12345), BrokenTradeMessage),
+        ]
+
+        for data, expected_class in test_cases:
+            message = ITCH4MarketMessage.from_bytes(data)
+            assert isinstance(message, expected_class), (
+                f"Failed for {expected_class.__name__}"
+            )

--- a/tests/test_itch4_processor.py
+++ b/tests/test_itch4_processor.py
@@ -1,0 +1,463 @@
+"""Tests for ITCH 4.0 market processor functionality."""
+
+import datetime
+import pytest
+
+from meatpy.itch4.itch4_market_processor import (
+    ITCH4MarketProcessor,
+    InvalidBuySellIndicatorError,
+    InvalidTradingStatusError,
+)
+from meatpy.itch4.itch4_market_message import (
+    SecondsMessage,
+    SystemEventMessage,
+    StockTradingActionMessage,
+    AddOrderMessage,
+    AddOrderMPIDMessage,
+    OrderExecutedMessage,
+    OrderExecutedPriceMessage,
+    OrderCancelMessage,
+    OrderDeleteMessage,
+    OrderReplaceMessage,
+    TradeMessage,
+)
+from meatpy.lob import OrderType
+from meatpy.trading_status import (
+    PreTradeTradingStatus,
+    TradeTradingStatus,
+    PostTradeTradingStatus,
+    HaltedTradingStatus,
+    QuoteOnlyTradingStatus,
+)
+
+
+class TestITCH4MarketProcessor:
+    """Test the ITCH4MarketProcessor class."""
+
+    def test_init(self):
+        """Test processor initialization."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        assert processor.instrument == "AAPL"
+        assert processor.book_date == book_date
+        assert processor.lob is None
+        assert processor.current_second == 0
+
+    def test_adjust_timestamp(self):
+        """Test timestamp adjustment from seconds + nanoseconds."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        # 36000 seconds = 10 hours, 500000000 nanoseconds = 0.5 seconds
+        timestamp = processor.adjust_timestamp(36000, 500000000)
+
+        # Should be book_date + 36000.5 seconds
+        # Timestamp extends datetime, so compare directly
+        expected = book_date + datetime.timedelta(seconds=36000.5)
+        assert timestamp.year == expected.year
+        assert timestamp.month == expected.month
+        assert timestamp.day == expected.day
+        assert timestamp.hour == expected.hour
+        assert timestamp.minute == expected.minute
+        assert timestamp.second == expected.second
+
+    def test_process_seconds_message(self):
+        """Test processing seconds message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        message = SecondsMessage()
+        message.seconds = 36000
+
+        processor.process_message(message)
+
+        assert processor.current_second == 36000
+
+    def test_process_system_event_start_messages(self):
+        """Test processing system event message - start of messages."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        message = SystemEventMessage()
+        message.timestamp = 0
+        message.event_code = b"O"
+
+        processor.process_message(message)
+
+        assert processor.system_status == b"O"
+        assert processor.trading_status == PostTradeTradingStatus
+
+    def test_process_system_event_start_system(self):
+        """Test processing system event message - start of system hours."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        message = SystemEventMessage()
+        message.timestamp = 0
+        message.event_code = b"S"
+
+        processor.process_message(message)
+
+        assert processor.system_status == b"S"
+        assert processor.trading_status == PreTradeTradingStatus
+
+    def test_process_stock_trading_action(self):
+        """Test processing stock trading action message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        # Start market first
+        sys_msg = SystemEventMessage()
+        sys_msg.timestamp = 0
+        sys_msg.event_code = b"Q"
+        processor.process_message(sys_msg)
+
+        # Then set stock trading status
+        action_msg = StockTradingActionMessage()
+        action_msg.timestamp = 0
+        action_msg.stock = b"AAPL  "
+        action_msg.state = b"T"
+        action_msg.reserved = b"     "
+        processor.process_message(action_msg)
+
+        assert processor.stock_status == b"T"
+        assert processor.trading_status == TradeTradingStatus
+
+    def test_process_stock_trading_action_halted(self):
+        """Test processing stock trading action message - halted."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        # Start market
+        sys_msg = SystemEventMessage()
+        sys_msg.timestamp = 0
+        sys_msg.event_code = b"Q"
+        processor.process_message(sys_msg)
+
+        # Set stock as halted
+        action_msg = StockTradingActionMessage()
+        action_msg.timestamp = 0
+        action_msg.stock = b"AAPL  "
+        action_msg.state = b"H"
+        action_msg.reserved = b"     "
+        processor.process_message(action_msg)
+
+        assert processor.stock_status == b"H"
+        assert processor.trading_status == HaltedTradingStatus
+
+    def test_process_stock_trading_action_quote_only(self):
+        """Test processing stock trading action message - quote only."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        # Start market
+        sys_msg = SystemEventMessage()
+        sys_msg.timestamp = 0
+        sys_msg.event_code = b"Q"
+        processor.process_message(sys_msg)
+
+        # Set stock as quote only
+        action_msg = StockTradingActionMessage()
+        action_msg.timestamp = 0
+        action_msg.stock = b"AAPL  "
+        action_msg.state = b"Q"
+        action_msg.reserved = b"     "
+        processor.process_message(action_msg)
+
+        assert processor.stock_status == b"Q"
+        assert processor.trading_status == QuoteOnlyTradingStatus
+
+    def test_process_stock_trading_action_different_stock(self):
+        """Test that trading actions for different stocks are ignored."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        action_msg = StockTradingActionMessage()
+        action_msg.timestamp = 0
+        action_msg.stock = b"MSFT  "
+        action_msg.state = b"T"
+        action_msg.reserved = b"     "
+        processor.process_message(action_msg)
+
+        # Stock status should remain empty
+        assert processor.stock_status == b""
+
+    def test_process_add_order_buy(self):
+        """Test processing add order message - buy side."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMessage()
+        message.timestamp = 12345
+        message.order_ref = 1
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+
+        processor.process_message(message)
+
+        assert processor.lob is not None
+        order_type = processor.lob.find_order_type(1)
+        assert order_type == OrderType.BID
+
+    def test_process_add_order_sell(self):
+        """Test processing add order message - sell side."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMessage()
+        message.timestamp = 12345
+        message.order_ref = 2
+        message.side = b"S"
+        message.shares = 200
+        message.stock = b"AAPL  "
+        message.price = 151000
+
+        processor.process_message(message)
+
+        assert processor.lob is not None
+        order_type = processor.lob.find_order_type(2)
+        assert order_type == OrderType.ASK
+
+    def test_process_add_order_invalid_side(self):
+        """Test processing add order with invalid side."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMessage()
+        message.timestamp = 12345
+        message.order_ref = 1
+        message.side = b"X"  # Invalid side
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+
+        with pytest.raises(InvalidBuySellIndicatorError):
+            processor.process_message(message)
+
+    def test_process_add_order_different_instrument(self):
+        """Test that orders for different instruments are ignored."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMessage()
+        message.timestamp = 12345
+        message.order_ref = 1
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"MSFT  "
+        message.price = 150000
+
+        processor.process_message(message)
+
+        assert processor.lob is None
+
+    def test_process_add_order_mpid(self):
+        """Test processing add order with MPID message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMPIDMessage()
+        message.timestamp = 12345
+        message.order_ref = 1
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+        message.mpid = b"ABCD"
+
+        processor.process_message(message)
+
+        assert processor.lob is not None
+        order_type = processor.lob.find_order_type(1)
+        assert order_type == OrderType.BID
+
+    def test_process_add_order_mpid_invalid_side(self):
+        """Test processing add order MPID with invalid side."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        message = AddOrderMPIDMessage()
+        message.timestamp = 12345
+        message.order_ref = 1
+        message.side = b"X"  # Invalid side
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+        message.mpid = b"ABCD"
+
+        with pytest.raises(InvalidBuySellIndicatorError):
+            processor.process_message(message)
+
+    def test_process_order_executed(self):
+        """Test processing order executed message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        # First add an order
+        add_msg = AddOrderMessage()
+        add_msg.timestamp = 12345
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        processor.process_message(add_msg)
+
+        # Then execute part of it
+        exec_msg = OrderExecutedMessage()
+        exec_msg.timestamp = 12346
+        exec_msg.order_ref = 1
+        exec_msg.shares = 50
+        exec_msg.match_number = 123
+        processor.process_message(exec_msg)
+
+    def test_process_order_executed_price(self):
+        """Test processing order executed with price message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        # First add an order
+        add_msg = AddOrderMessage()
+        add_msg.timestamp = 12345
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        processor.process_message(add_msg)
+
+        # Then execute with different price
+        exec_msg = OrderExecutedPriceMessage()
+        exec_msg.timestamp = 12346
+        exec_msg.order_ref = 1
+        exec_msg.shares = 50
+        exec_msg.match_number = 123
+        exec_msg.printable = b"Y"
+        exec_msg.price = 149500
+        processor.process_message(exec_msg)
+
+    def test_process_order_cancel(self):
+        """Test processing order cancel message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        # First add an order
+        add_msg = AddOrderMessage()
+        add_msg.timestamp = 12345
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        processor.process_message(add_msg)
+
+        # Then cancel part of it
+        cancel_msg = OrderCancelMessage()
+        cancel_msg.timestamp = 12346
+        cancel_msg.order_ref = 1
+        cancel_msg.shares = 25
+        processor.process_message(cancel_msg)
+
+    def test_process_order_delete(self):
+        """Test processing order delete message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        # First add an order
+        add_msg = AddOrderMessage()
+        add_msg.timestamp = 12345
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        processor.process_message(add_msg)
+
+        # Then delete it
+        delete_msg = OrderDeleteMessage()
+        delete_msg.timestamp = 12346
+        delete_msg.order_ref = 1
+        processor.process_message(delete_msg)
+
+    def test_process_order_replace(self):
+        """Test processing order replace message."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        # First add an order
+        add_msg = AddOrderMessage()
+        add_msg.timestamp = 12345
+        add_msg.order_ref = 1
+        add_msg.side = b"B"
+        add_msg.shares = 100
+        add_msg.stock = b"AAPL  "
+        add_msg.price = 150000
+        processor.process_message(add_msg)
+
+        # Then replace it
+        replace_msg = OrderReplaceMessage()
+        replace_msg.timestamp = 12346
+        replace_msg.original_ref = 1
+        replace_msg.new_ref = 2
+        replace_msg.shares = 150
+        replace_msg.price = 151000
+        processor.process_message(replace_msg)
+
+        # New order should exist
+        assert processor.lob is not None
+        order_type = processor.lob.find_order_type(2)
+        assert order_type == OrderType.BID
+
+    def test_process_trade_message(self):
+        """Test processing trade message (hidden order)."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        message = TradeMessage()
+        message.timestamp = 12345
+        message.order_ref = 999
+        message.side = b"S"
+        message.shares = 50
+        message.stock = b"AAPL  "
+        message.price = 150000
+        message.match_number = 123
+        processor.process_message(message)  # Should not raise
+
+    def test_process_wrong_message_type(self):
+        """Test that wrong message type raises TypeError."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        with pytest.raises(TypeError):
+            processor.process_message("not a message")  # type: ignore
+
+    def test_instrument_bytes(self):
+        """Test processor with bytes instrument."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor(b"AAPL  ", book_date)
+
+        message = AddOrderMessage()
+        message.timestamp = 12345
+        message.order_ref = 1
+        message.side = b"B"
+        message.shares = 100
+        message.stock = b"AAPL  "
+        message.price = 150000
+
+        processor.process_message(message)
+
+        assert processor.lob is not None
+
+    def test_trading_status_unknown_raises_error(self):
+        """Test that unknown trading status raises error."""
+        book_date = datetime.datetime(2023, 1, 15)
+        processor = ITCH4MarketProcessor("AAPL", book_date)
+
+        # Set an invalid system status
+        processor.system_status = b"X"  # Unknown
+
+        with pytest.raises(InvalidTradingStatusError):
+            processor._determine_trading_status()

--- a/tests/test_itch4_reader.py
+++ b/tests/test_itch4_reader.py
@@ -1,0 +1,209 @@
+"""Tests for ITCH 4.0 message reader functionality."""
+
+import gzip
+import struct
+import tempfile
+import pytest
+from pathlib import Path
+
+from meatpy.itch4.itch4_message_reader import ITCH4MessageReader
+from meatpy.itch4.itch4_market_message import (
+    SecondsMessage,
+    SystemEventMessage,
+    AddOrderMessage,
+)
+
+
+class TestITCH4MessageReader:
+    """Test the ITCH4MessageReader class."""
+
+    def create_test_data(self) -> bytes:
+        """Create test ITCH 4.0 data with a few messages."""
+        messages_data = b""
+
+        # Create a seconds message: T(1) + seconds(4) = 5 bytes
+        seconds_msg = struct.pack("!cI", b"T", 12345)
+        messages_data += b"\x00"  # Start byte
+        messages_data += bytes([len(seconds_msg)])  # Length
+        messages_data += seconds_msg
+
+        # Create a system event message: S(1) + timestamp(4) + event_code(1) = 6 bytes
+        system_msg = struct.pack("!cIc", b"S", 12346, b"O")
+        messages_data += b"\x00"  # Start byte
+        messages_data += bytes([len(system_msg)])  # Length
+        messages_data += system_msg
+
+        # Create an add order message: A(1) + timestamp(4) + order_ref(8) + side(1) + shares(4) + stock(6) + price(4) = 28 bytes
+        add_msg = struct.pack(
+            "!cIQcI6sI", b"A", 12347, 999, b"B", 100, b"AAPL  ", 150000
+        )
+        messages_data += b"\x00"  # Start byte
+        messages_data += bytes([len(add_msg)])  # Length
+        messages_data += add_msg
+
+        return messages_data
+
+    def test_read_file_uncompressed(self):
+        """Test reading uncompressed ITCH 4.0 file."""
+        test_data = self.create_test_data()
+
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            reader = ITCH4MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 3
+            assert isinstance(messages[0], SecondsMessage)
+            assert isinstance(messages[1], SystemEventMessage)
+            assert isinstance(messages[2], AddOrderMessage)
+
+            # Check first message details
+            assert messages[0].seconds == 12345
+
+            # Check second message details
+            assert messages[1].event_code == b"O"
+            assert messages[1].timestamp == 12346
+
+            # Check third message details
+            assert messages[2].side == b"B"
+            assert messages[2].shares == 100
+            assert messages[2].price == 150000
+
+    def test_read_file_gzip_compressed(self):
+        """Test reading gzip compressed ITCH 4.0 file."""
+        test_data = self.create_test_data()
+
+        with tempfile.NamedTemporaryFile(suffix=".gz", delete=False) as temp_file:
+            with gzip.open(temp_file.name, "wb") as gz_file:
+                gz_file.write(test_data)
+
+            reader = ITCH4MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 3
+            assert isinstance(messages[0], SecondsMessage)
+            assert isinstance(messages[1], SystemEventMessage)
+
+    def test_context_manager_usage(self):
+        """Test using the reader as a context manager."""
+        test_data = self.create_test_data()
+
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            messages = []
+            with ITCH4MessageReader(temp_file.name) as reader:
+                for message in reader:
+                    messages.append(message)
+
+            assert len(messages) == 3
+            assert isinstance(messages[0], SecondsMessage)
+            assert isinstance(messages[1], SystemEventMessage)
+            assert isinstance(messages[2], AddOrderMessage)
+
+    def test_context_manager_without_file_path(self):
+        """Test context manager error when no file path provided."""
+        reader = ITCH4MessageReader()
+
+        with pytest.raises(ValueError, match="No file_path provided"):
+            with reader:
+                pass
+
+    def test_iterator_without_context_manager(self):
+        """Test iterator error when not used as context manager."""
+        reader = ITCH4MessageReader()
+
+        with pytest.raises(
+            RuntimeError, match="Reader must be used as a context manager"
+        ):
+            next(iter(reader))
+
+    def test_empty_file(self):
+        """Test reading an empty file."""
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            pass
+
+        reader = ITCH4MessageReader()
+        messages = list(reader.read_file(temp_file.name))
+
+        assert len(messages) == 0
+
+    def test_invalid_message_format(self):
+        """Test handling of invalid message format."""
+        # Create data with invalid start byte
+        invalid_data = b"\x01\x10" + b"A" * 16  # Start byte should be 0x00
+
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(invalid_data)
+            temp_file.flush()
+
+            reader = ITCH4MessageReader()
+
+            with pytest.raises(Exception):  # Should raise InvalidMessageFormatError
+                list(reader.read_file(temp_file.name))
+
+    def test_large_buffer_handling(self):
+        """Test reading with large amounts of data to test buffer management."""
+        messages_data = b""
+
+        for i in range(100):  # Create 100 messages
+            msg = struct.pack("!cI", b"T", 12345 + i)
+            messages_data += b"\x00"
+            messages_data += bytes([len(msg)])
+            messages_data += msg
+
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(messages_data)
+            temp_file.flush()
+
+            reader = ITCH4MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            assert len(messages) == 100
+
+            # Check that all messages are correct
+            for i, message in enumerate(messages):
+                assert isinstance(message, SecondsMessage)
+                assert message.seconds == 12345 + i
+
+    def test_incomplete_message_at_end(self):
+        """Test handling of incomplete message at end of file."""
+        # Create one complete message followed by incomplete data
+        complete_msg = struct.pack("!cI", b"T", 12345)
+        complete_data = b"\x00" + bytes([len(complete_msg)]) + complete_msg
+        incomplete_data = b"\x00\x10" + b"A" * 5  # Claims 16 bytes but only has 5
+
+        test_data = complete_data + incomplete_data
+
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            reader = ITCH4MessageReader()
+            messages = list(reader.read_file(temp_file.name))
+
+            # Should only get the complete message
+            assert len(messages) == 1
+            assert isinstance(messages[0], SecondsMessage)
+
+    def test_pathlib_path_support(self):
+        """Test that Path objects are supported."""
+        test_data = self.create_test_data()
+
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(test_data)
+            temp_file.flush()
+
+            # Use Path object instead of string
+            file_path = Path(temp_file.name)
+
+            reader = ITCH4MessageReader()
+            messages = list(reader.read_file(file_path))
+
+            assert len(messages) == 3
+            assert isinstance(messages[0], SecondsMessage)
+            assert isinstance(messages[1], SystemEventMessage)
+            assert isinstance(messages[2], AddOrderMessage)


### PR DESCRIPTION
## Summary

- Adds ITCH 2.0 support (ASCII format, 6 message types, embedded millisecond timestamps)
- Adds ITCH 3.0 support (ASCII format, 16 message types, separate timestamp messages)
- Adds ITCH 4.0 support (Binary format, 6-character stock symbols, nanosecond timestamps)
- Updates documentation with version comparison table and usage examples

Each module provides `MessageReader`, `MarketProcessor`, and `MarketMessage` classes following the same patterns as existing ITCH 4.1 and 5.0 modules.

Closes #80

## Test plan

- [ ] Verify ITCH 2.0 module parses sample files correctly
- [ ] Verify ITCH 3.0 module parses sample files correctly
- [ ] Verify ITCH 4.0 module parses sample files correctly
- [ ] Verify LOB reconstruction works for each version
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)