### PR TITLE
feat: add support for IEX DEEP 1.0 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@
 
 <img src="docs/images/meatpy.svg" width="200" alt="MeatPy Logo"/>
 
-MeatPy is a Python framework for processing and analyzing high-frequency financial market data, specifically designed for working with NASDAQ ITCH protocol data feeds. It provides robust tools for reconstructing limit order books and extracting key market events from historical market data files.
+MeatPy is a Python framework for processing and analyzing high-frequency financial market data, specifically designed for working with NASDAQ ITCH and IEX DEEP data feeds. It provides robust tools for reconstructing limit order books and extracting key market events from historical market data files.
 
 ## 🎯 Key Features
 
 - **📊 Limit Order Book Reconstruction**: Complete order book state tracking with proper handling of all order types and modifications
 - **🏛️ NASDAQ ITCH Support**: Full implementation for ITCH 5.0 and 4.1 protocols with native message parsing
+- **📈 IEX DEEP Support**: Full implementation for IEX DEEP 1.0 format with price-level order book reconstruction
 - **⚡ Event-Driven Architecture**: Flexible observer pattern for real-time event processing and analysis
 - **🔒 Type Safety**: Modern Python with comprehensive type hints and generic interfaces for robust data handling
 - **📁 Multiple Output Formats**: Export to CSV, Parquet, or implement custom output formats
-- **🚀 Performance Optimized**: Efficiently process multi-gigabyte ITCH files with streaming capabilities
+- **🚀 Performance Optimized**: Efficiently process multi-gigabyte data files with streaming capabilities
 - **🔧 Extensible Design**: Easy to adapt for other market data formats and custom analysis needs
 
 ## 📊 Common Use Cases
@@ -142,6 +143,28 @@ with ITCH50MessageReader(file_path) as reader, ParquetWriter(outfile_path) as wr
 
     for message in reader:
         processor.process_message(message)
+```
+
+### Reading IEX DEEP Data
+
+IEX DEEP provides aggregated price-level data (not individual orders like ITCH):
+
+```python
+from meatpy.iex_deep import IEXDEEPMessageReader, IEXDEEPMarketProcessor
+
+# Read and process IEX DEEP messages
+reader = IEXDEEPMessageReader()
+processor = IEXDEEPMarketProcessor("SPY")
+
+for message in reader.read_file("data_feeds_20180529_DEEP1.0.pcap.gz"):
+    processor.process_message(message)
+
+# Get best bid and offer
+bbo = processor.get_bbo()
+if bbo[0] and bbo[1]:
+    # Prices have 4 decimal places (divide by 10000)
+    print(f"Best Bid: ${bbo[0][0]/10000:.2f} x {bbo[0][1]}")
+    print(f"Best Ask: ${bbo[1][0]/10000:.2f} x {bbo[1][1]}")
 ```
 
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -15,7 +15,8 @@ This guide will help you get started with MeatPy for processing financial market
 
 MeatPy currently supports:
 
-- **ITCH 5.0**: NASDAQ's binary market data format
+- **ITCH 4.1/5.0**: NASDAQ's binary market data format (order-level data)
+- **IEX DEEP 1.0**: IEX Exchange's market data format (price-level data)
 
 ## Basic Usage
 
@@ -33,7 +34,35 @@ with ITCH50MessageReader("market_data.txt.gz") as reader:
 ```
 
 
-Other common tasks include:
+## Reading IEX DEEP Data
+
+IEX DEEP data comes in PCAP/PCAP-NG format. Here's how to read it:
+
+```python
+from meatpy.iex_deep import IEXDEEPMessageReader, IEXDEEPMarketProcessor
+
+# Read messages from a PCAP file
+reader = IEXDEEPMessageReader()
+for i, message in enumerate(reader.read_file("data_feeds_20180529_DEEP1.0.pcap.gz")):
+    print(f"Message {i}: {type(message).__name__}")
+    if i >= 10:
+        break
+
+# Process messages and reconstruct order book for a specific symbol
+processor = IEXDEEPMarketProcessor("SPY")
+for message in reader.read_file("data_feeds_20180529_DEEP1.0.pcap.gz"):
+    processor.process_message(message)
+
+# Get best bid and offer
+bbo = processor.get_bbo()
+if bbo[0] and bbo[1]:
+    print(f"Best Bid: ${bbo[0][0]/10000:.2f} x {bbo[0][1]}")
+    print(f"Best Ask: ${bbo[1][0]/10000:.2f} x {bbo[1][1]}")
+```
+
+For more details on IEX DEEP, see the [IEX DEEP Guide](iex-deep.md).
+
+## Other Common Tasks
 
 - **Listing Symbols**: Extracting unique stock symbols from ITCH files
 - **Extracting Specific Symbols**: Creating new ITCH files with only specific symbols

--- a/docs/guide/iex-deep.md
+++ b/docs/guide/iex-deep.md
@@ -1,0 +1,244 @@
+# IEX DEEP Guide
+
+This guide covers working with IEX DEEP market data in MeatPy.
+
+## Overview
+
+IEX DEEP is a market data feed from IEX Exchange that provides real-time depth of book quotations. Unlike NASDAQ ITCH which provides individual order-level data, IEX DEEP provides **aggregated price-level data** - the total size available at each price level rather than individual orders.
+
+### Key Characteristics
+
+| Feature | IEX DEEP | NASDAQ ITCH |
+|---------|----------|-------------|
+| Data granularity | Price levels (aggregated) | Individual orders |
+| Byte order | Little endian | Big endian |
+| Timestamps | Nanoseconds since POSIX epoch | Nanoseconds since midnight |
+| File format | PCAP/PCAP-NG | Raw binary |
+| Price format | 8 bytes, 4 decimal places | 4 bytes, 4 decimal places |
+
+## Data Format
+
+IEX DEEP data is distributed in PCAP or PCAP-NG file format, with messages encapsulated in the IEX Transport Protocol (IEX-TP). MeatPy handles all the transport layer parsing automatically.
+
+### Message Types
+
+IEX DEEP 1.0 includes 12 message types:
+
+| Type | Code | Description |
+|------|------|-------------|
+| System Event | S | Market-wide events (start/end of day) |
+| Security Directory | D | Security information for IEX-listed securities |
+| Trading Status | H | Trading status updates (halted, trading, etc.) |
+| Operational Halt | O | Operational halt status |
+| Short Sale Price Test | P | Short sale restriction status |
+| Security Event | E | Opening/closing auction events |
+| Price Level Update (Buy) | 8 | Bid side price level update |
+| Price Level Update (Sell) | 5 | Ask side price level update |
+| Trade Report | T | Trade execution reports |
+| Official Price | X | Official opening/closing prices |
+| Trade Break | B | Trade cancellation |
+| Auction Information | A | Auction imbalance information |
+
+## Basic Usage
+
+### Reading Messages
+
+```python
+from meatpy.iex_deep import IEXDEEPMessageReader
+
+reader = IEXDEEPMessageReader()
+
+# Read from a PCAP file (supports .gz, .bz2, .xz compression)
+for message in reader.read_file("data_feeds_20180529_DEEP1.0.pcap.gz"):
+    print(f"{type(message).__name__}: {message.timestamp}")
+```
+
+### Processing Messages
+
+The `IEXDEEPMarketProcessor` reconstructs the order book for a specific symbol:
+
+```python
+from meatpy.iex_deep import IEXDEEPMessageReader, IEXDEEPMarketProcessor
+
+# Create a processor for SPY
+processor = IEXDEEPMarketProcessor("SPY")
+reader = IEXDEEPMessageReader()
+
+for message in reader.read_file("data_feeds_20180529_DEEP1.0.pcap.gz"):
+    processor.process_message(message)
+
+# Get the current best bid and offer
+best_bid = processor.get_best_bid()  # Returns (price, size) or None
+best_ask = processor.get_best_ask()  # Returns (price, size) or None
+bbo = processor.get_bbo()            # Returns (best_bid, best_ask)
+
+if best_bid and best_ask:
+    # Prices are in integer format with 4 decimal places
+    bid_price = best_bid[0] / 10000
+    ask_price = best_ask[0] / 10000
+    print(f"BBO: ${bid_price:.4f} x {best_bid[1]} | ${ask_price:.4f} x {best_ask[1]}")
+```
+
+### Accessing Price Levels
+
+The processor maintains dictionaries of all price levels:
+
+```python
+# Access all bid levels (price -> size)
+for price in sorted(processor._bid_levels.keys(), reverse=True):
+    size = processor._bid_levels[price]
+    print(f"Bid: ${price/10000:.4f} x {size}")
+
+# Access all ask levels (price -> size)
+for price in sorted(processor._ask_levels.keys()):
+    size = processor._ask_levels[price]
+    print(f"Ask: ${price/10000:.4f} x {size}")
+```
+
+### Tracking Trades
+
+Trade IDs are tracked automatically:
+
+```python
+# After processing messages
+print(f"Number of trades: {len(processor._trade_ids)}")
+```
+
+## Working with Specific Message Types
+
+### Price Level Updates
+
+Price level updates tell you the new total size at a price level. A size of 0 means the level should be removed:
+
+```python
+from meatpy.iex_deep.iex_deep_market_message import (
+    PriceLevelUpdateBuySideMessage,
+    PriceLevelUpdateSellSideMessage,
+)
+
+for message in reader.read_file(filename):
+    if isinstance(message, PriceLevelUpdateBuySideMessage):
+        symbol = message.symbol.decode().strip()
+        price = message.price / 10000
+        size = message.size
+        print(f"BID {symbol}: ${price:.4f} x {size}")
+
+    elif isinstance(message, PriceLevelUpdateSellSideMessage):
+        symbol = message.symbol.decode().strip()
+        price = message.price / 10000
+        size = message.size
+        print(f"ASK {symbol}: ${price:.4f} x {size}")
+```
+
+### Trade Reports
+
+```python
+from meatpy.iex_deep.iex_deep_market_message import TradeReportMessage
+
+for message in reader.read_file(filename):
+    if isinstance(message, TradeReportMessage):
+        symbol = message.symbol.decode().strip()
+        price = message.price / 10000
+        size = message.size
+        trade_id = message.trade_id
+        print(f"TRADE {symbol}: {size} @ ${price:.4f} (ID: {trade_id})")
+```
+
+### System Events
+
+```python
+from meatpy.iex_deep.iex_deep_market_message import SystemEventMessage
+
+SYSTEM_EVENTS = {
+    b"O": "Start of Messages",
+    b"S": "Start of System Hours",
+    b"R": "Start of Regular Market Hours",
+    b"M": "End of Regular Market Hours",
+    b"E": "End of System Hours",
+    b"C": "End of Messages",
+}
+
+for message in reader.read_file(filename):
+    if isinstance(message, SystemEventMessage):
+        event_name = SYSTEM_EVENTS.get(message.system_event, "Unknown")
+        print(f"System Event: {event_name}")
+```
+
+## Differences from ITCH Processing
+
+### No Individual Order Tracking
+
+Unlike ITCH, IEX DEEP does not provide individual order IDs for quotes. The processor tracks aggregated price levels only:
+
+```python
+# ITCH: tracks individual orders
+# processor.current_lob.bid_levels[0].queue  # List of individual orders
+
+# IEX DEEP: tracks aggregated levels
+# processor._bid_levels  # {price: total_size}
+```
+
+### Timestamp Handling
+
+IEX DEEP timestamps are nanoseconds since the POSIX epoch (January 1, 1970), not nanoseconds since midnight like ITCH:
+
+```python
+import datetime
+
+# Convert IEX DEEP timestamp to datetime
+timestamp_ns = message.timestamp
+timestamp_s = timestamp_ns / 1_000_000_000
+dt = datetime.datetime.fromtimestamp(timestamp_s, tz=datetime.timezone.utc)
+print(f"Time: {dt}")
+```
+
+## Data Sources
+
+IEX DEEP historical data can be obtained from:
+
+- [IEX Cloud](https://iexcloud.io/) - Historical DEEP data
+- [IEX Exchange](https://exchange.iex.io/products/market-data/) - Direct exchange data
+
+Sample data files are typically named like:
+```
+data_feeds_YYYYMMDD_YYYYMMDD_IEXTP1_DEEP1.0.pcap.gz
+```
+
+## API Reference
+
+### IEXDEEPMessageReader
+
+```python
+class IEXDEEPMessageReader:
+    def read_file(self, filename: str) -> Generator[IEXDEEPMarketMessage, None, None]:
+        """Read messages from a PCAP/PCAP-NG file.
+
+        Supports compressed files (.gz, .bz2, .xz, .zip).
+        """
+```
+
+### IEXDEEPMarketProcessor
+
+```python
+class IEXDEEPMarketProcessor:
+    def __init__(self, instrument: str | bytes, book_date: datetime = None, track_lob: bool = False):
+        """Initialize processor for a specific symbol.
+
+        Args:
+            instrument: Symbol to track (e.g., "SPY")
+            book_date: Trading date (optional, defaults to current date)
+            track_lob: Whether to track full LOB (default False)
+        """
+
+    def process_message(self, message: IEXDEEPMarketMessage) -> None:
+        """Process a single market message."""
+
+    def get_best_bid(self) -> tuple[int, int] | None:
+        """Get best bid (price, size) or None if no bids."""
+
+    def get_best_ask(self) -> tuple[int, int] | None:
+        """Get best ask (price, size) or None if no asks."""
+
+    def get_bbo(self) -> tuple[tuple[int, int] | None, tuple[int, int] | None]:
+        """Get (best_bid, best_ask) tuple."""
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,12 +2,13 @@
 
 # MeatPy
 
-MeatPy is a Python framework for processing financial market data, specifically designed for limit order book reconstruction and analysis. It provides efficient tools for handling high-frequency trading data formats like NASDAQ ITCH.
+MeatPy is a Python framework for processing financial market data, specifically designed for limit order book reconstruction and analysis. It provides efficient tools for handling high-frequency trading data formats like NASDAQ ITCH and IEX DEEP.
 
 ## Key Features
 
 - **Limit Order Book Processing**: Complete reconstruction and analysis of limit order books
 - **ITCH Support**: Full implementation for NASDAQ ITCH 4.1 and 5.0 formats
+- **IEX DEEP Support**: Full implementation for IEX DEEP 1.0 format (price-level data)
 - **Event-Driven Architecture**: Extensible framework for real-time market data processing
 - **Type Safety**: Modern Python typing for robust financial data handling
 - **Multiple Output Formats**: Support for CSV, Parquet, and custom formats

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
   - Installation: installation.md
   - User Guide:
     - Getting Started: guide/getting-started.md
+    - IEX DEEP Guide: guide/iex-deep.md
     - Listing Symbols: guide/01_listing_symbols.ipynb
     - Extracting Symbols: guide/02_extracting_symbols.ipynb
     - Top of Book Snapshots: guide/03_top_of_book_snapshots.ipynb

--- a/src/meatpy/__init__.py
+++ b/src/meatpy/__init__.py
@@ -77,3 +77,10 @@ try:
     __all__.extend(["itch50"])
 except ImportError:
     pass
+
+try:
+    from . import iex_deep  # noqa: F401
+
+    __all__.extend(["iex_deep"])
+except ImportError:
+    pass

--- a/src/meatpy/iex_deep/__init__.py
+++ b/src/meatpy/iex_deep/__init__.py
@@ -1,0 +1,55 @@
+"""IEX DEEP market data subpackage.
+
+This package provides message types, parsers, processors, and readers for handling
+IEX DEEP market data in MeatPy.
+
+IEX DEEP provides real-time depth of book quotations and last sale information from
+the Investors Exchange (IEX). Unlike ITCH 5.0, IEX DEEP provides aggregated price
+level updates rather than individual orders.
+
+Key differences from ITCH 5.0:
+- Little endian byte order (vs big endian for ITCH)
+- Timestamps are nanoseconds since POSIX epoch (vs nanoseconds since midnight)
+- Price levels are aggregated (vs individual orders)
+- Data is delivered in PCAP files with IEX-TP transport protocol
+"""
+
+from .iex_deep_market_message import (
+    AuctionInformationMessage,
+    IEXDEEPMarketMessage,
+    OperationalHaltStatusMessage,
+    OfficialPriceMessage,
+    PriceLevelUpdateBuySideMessage,
+    PriceLevelUpdateMessage,
+    PriceLevelUpdateSellSideMessage,
+    SecurityDirectoryMessage,
+    SecurityEventMessage,
+    ShortSalePriceTestStatusMessage,
+    SystemEventMessage,
+    TradeBreakMessage,
+    TradeReportMessage,
+    TradingStatusMessage,
+)
+from .iex_deep_market_processor import IEXDEEPMarketProcessor
+from .iex_deep_message_reader import IEXDEEPMessageReader
+
+__all__ = [
+    # Main classes
+    "IEXDEEPMarketMessage",
+    "IEXDEEPMarketProcessor",
+    "IEXDEEPMessageReader",
+    # Message types
+    "AuctionInformationMessage",
+    "OperationalHaltStatusMessage",
+    "OfficialPriceMessage",
+    "PriceLevelUpdateBuySideMessage",
+    "PriceLevelUpdateMessage",
+    "PriceLevelUpdateSellSideMessage",
+    "SecurityDirectoryMessage",
+    "SecurityEventMessage",
+    "ShortSalePriceTestStatusMessage",
+    "SystemEventMessage",
+    "TradeBreakMessage",
+    "TradeReportMessage",
+    "TradingStatusMessage",
+]

--- a/src/meatpy/iex_deep/iex_deep_market_message.py
+++ b/src/meatpy/iex_deep/iex_deep_market_message.py
@@ -1,0 +1,869 @@
+"""IEX DEEP market message types.
+
+This module provides message classes for IEX DEEP format market data.
+All messages use little endian byte order and timestamps are nanoseconds
+since POSIX (Epoch) time UTC.
+"""
+
+from __future__ import annotations
+
+import abc
+import json
+import struct
+from typing import Any
+
+from ..message_reader import MarketMessage, UnknownMessageTypeError
+
+
+class IEXDEEPMarketMessage(MarketMessage):
+    """Base class for IEX DEEP market messages.
+
+    All IEX DEEP messages share common characteristics:
+    - Little endian byte order
+    - Timestamps in nanoseconds since POSIX epoch UTC
+    - Message type as first byte
+    """
+
+    __metaclass__ = abc.ABCMeta
+
+    # Message type byte for this message class
+    message_type: bytes = b""
+
+    # Expected message length (excluding message type byte)
+    message_length: int = 0
+
+    def __init__(self, timestamp: int) -> None:
+        """Initialize the message with a timestamp.
+
+        Args:
+            timestamp: Nanoseconds since POSIX epoch UTC
+        """
+        self.timestamp = timestamp
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "IEXDEEPMarketMessage":
+        """Parse a message from bytes.
+
+        Args:
+            data: Raw message bytes (including message type byte)
+
+        Returns:
+            Parsed message object
+
+        Raises:
+            UnknownMessageTypeError: If message type is not recognized
+        """
+        if len(data) < 1:
+            raise ValueError("Message data is empty")
+
+        message_type = data[0:1]
+
+        # Map message types to classes
+        message_classes: dict[bytes, type[IEXDEEPMarketMessage]] = {
+            b"S": SystemEventMessage,
+            b"D": SecurityDirectoryMessage,
+            b"H": TradingStatusMessage,
+            b"O": OperationalHaltStatusMessage,
+            b"P": ShortSalePriceTestStatusMessage,
+            b"E": SecurityEventMessage,
+            b"8": PriceLevelUpdateBuySideMessage,
+            b"5": PriceLevelUpdateSellSideMessage,
+            b"T": TradeReportMessage,
+            b"X": OfficialPriceMessage,
+            b"B": TradeBreakMessage,
+            b"A": AuctionInformationMessage,
+        }
+
+        if message_type not in message_classes:
+            raise UnknownMessageTypeError(
+                f"Unknown IEX DEEP message type: {message_type!r}"
+            )
+
+        return message_classes[message_type]._from_bytes(data)
+
+    @classmethod
+    @abc.abstractmethod
+    def _from_bytes(cls, data: bytes) -> "IEXDEEPMarketMessage":
+        """Internal method to parse message from bytes.
+
+        Args:
+            data: Raw message bytes
+
+        Returns:
+            Parsed message object
+        """
+        pass
+
+    @abc.abstractmethod
+    def to_bytes(self) -> bytes:
+        """Serialize message to bytes.
+
+        Returns:
+            Raw message bytes
+        """
+        pass
+
+    def to_json(self) -> str:
+        """Serialize message to JSON string.
+
+        Returns:
+            JSON string representation
+        """
+        d: dict[str, Any] = {
+            "message_type": self.message_type.decode("ascii"),
+            "timestamp": self.timestamp,
+        }
+        self._add_json_fields(d)
+        return json.dumps(d)
+
+    def _add_json_fields(self, d: dict[str, Any]) -> None:
+        """Add message-specific fields to JSON dict.
+
+        Args:
+            d: Dictionary to add fields to
+        """
+        pass
+
+
+class SystemEventMessage(IEXDEEPMarketMessage):
+    """System Event Message (S, 0x53).
+
+    Used to indicate events that apply to the market or data feed.
+    Total message length: 10 bytes.
+
+    System Events:
+    - 'O' (0x4f): Start of Messages
+    - 'S' (0x53): Start of System Hours
+    - 'R' (0x52): Start of Regular Market Hours
+    - 'M' (0x4d): End of Regular Market Hours
+    - 'E' (0x45): End of System Hours
+    - 'C' (0x43): End of Messages
+    """
+
+    message_type = b"S"
+    message_length = 10
+
+    def __init__(self, system_event: bytes, timestamp: int) -> None:
+        super().__init__(timestamp)
+        self.system_event = system_event
+
+    @classmethod
+    def _from_bytes(cls, data: bytes) -> "SystemEventMessage":
+        # Format: message_type(1) + system_event(1) + timestamp(8)
+        # Little endian: <
+        system_event, timestamp = struct.unpack("<xbq", data[:10])
+        return cls(
+            system_event=bytes([system_event]),
+            timestamp=timestamp,
+        )
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "<cbq",
+            self.message_type,
+            self.system_event[0],
+            self.timestamp,
+        )
+
+    def _add_json_fields(self, d: dict[str, Any]) -> None:
+        d["system_event"] = self.system_event.decode("ascii")
+
+
+class SecurityDirectoryMessage(IEXDEEPMarketMessage):
+    """Security Directory Message (D, 0x44).
+
+    Provides security information for IEX-listed securities.
+    Total message length: 31 bytes.
+    """
+
+    message_type = b"D"
+    message_length = 31
+
+    def __init__(
+        self,
+        flags: int,
+        timestamp: int,
+        symbol: bytes,
+        round_lot_size: int,
+        adjusted_poc_price: int,
+        luld_tier: int,
+    ) -> None:
+        super().__init__(timestamp)
+        self.flags = flags
+        self.symbol = symbol
+        self.round_lot_size = round_lot_size
+        self.adjusted_poc_price = adjusted_poc_price
+        self.luld_tier = luld_tier
+
+    @classmethod
+    def _from_bytes(cls, data: bytes) -> "SecurityDirectoryMessage":
+        # Format: type(1) + flags(1) + timestamp(8) + symbol(8) + round_lot(4) + poc_price(8) + luld(1)
+        flags, timestamp, symbol, round_lot_size, adjusted_poc_price, luld_tier = (
+            struct.unpack("<xBq8sIqB", data[:31])
+        )
+        return cls(
+            flags=flags,
+            timestamp=timestamp,
+            symbol=symbol,
+            round_lot_size=round_lot_size,
+            adjusted_poc_price=adjusted_poc_price,
+            luld_tier=luld_tier,
+        )
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "<cBq8sIqB",
+            self.message_type,
+            self.flags,
+            self.timestamp,
+            self.symbol,
+            self.round_lot_size,
+            self.adjusted_poc_price,
+            self.luld_tier,
+        )
+
+    def _add_json_fields(self, d: dict[str, Any]) -> None:
+        d["flags"] = self.flags
+        d["symbol"] = self.symbol.decode("ascii").strip()
+        d["round_lot_size"] = self.round_lot_size
+        d["adjusted_poc_price"] = self.adjusted_poc_price / 10000.0
+        d["luld_tier"] = self.luld_tier
+
+    @property
+    def is_test_security(self) -> bool:
+        """Check if this is a test security (bit 7)."""
+        return bool(self.flags & 0x80)
+
+    @property
+    def is_when_issued(self) -> bool:
+        """Check if this is a when issued security (bit 6)."""
+        return bool(self.flags & 0x40)
+
+    @property
+    def is_etp(self) -> bool:
+        """Check if this is an ETP (bit 5)."""
+        return bool(self.flags & 0x20)
+
+
+class TradingStatusMessage(IEXDEEPMarketMessage):
+    """Trading Status Message (H, 0x48).
+
+    Indicates current trading status of a security.
+    Total message length: 22 bytes.
+
+    Trading Status:
+    - 'H' (0x48): Trading halted
+    - 'O' (0x4f): Order Acceptance Period
+    - 'P' (0x50): Trading Paused
+    - 'T' (0x54): Trading on IEX
+    """
+
+    message_type = b"H"
+    message_length = 22
+
+    def __init__(
+        self,
+        trading_status: bytes,
+        timestamp: int,
+        symbol: bytes,
+        reason: bytes,
+    ) -> None:
+        super().__init__(timestamp)
+        self.trading_status = trading_status
+        self.symbol = symbol
+        self.reason = reason
+
+    @classmethod
+    def _from_bytes(cls, data: bytes) -> "TradingStatusMessage":
+        # Format: type(1) + status(1) + timestamp(8) + symbol(8) + reason(4)
+        trading_status, timestamp, symbol, reason = struct.unpack("<xbq8s4s", data[:22])
+        return cls(
+            trading_status=bytes([trading_status]),
+            timestamp=timestamp,
+            symbol=symbol,
+            reason=reason,
+        )
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "<cbq8s4s",
+            self.message_type,
+            self.trading_status[0],
+            self.timestamp,
+            self.symbol,
+            self.reason,
+        )
+
+    def _add_json_fields(self, d: dict[str, Any]) -> None:
+        d["trading_status"] = self.trading_status.decode("ascii")
+        d["symbol"] = self.symbol.decode("ascii").strip()
+        d["reason"] = self.reason.decode("ascii").strip()
+
+
+class OperationalHaltStatusMessage(IEXDEEPMarketMessage):
+    """Operational Halt Status Message (O, 0x4f).
+
+    Indicates operational halt status for a security.
+    Total message length: 18 bytes.
+
+    Operational Halt Status:
+    - 'O' (0x4f): IEX specific operational halt
+    - 'N' (0x4e): Not operationally halted on IEX
+    """
+
+    message_type = b"O"
+    message_length = 18
+
+    def __init__(
+        self,
+        operational_halt_status: bytes,
+        timestamp: int,
+        symbol: bytes,
+    ) -> None:
+        super().__init__(timestamp)
+        self.operational_halt_status = operational_halt_status
+        self.symbol = symbol
+
+    @classmethod
+    def _from_bytes(cls, data: bytes) -> "OperationalHaltStatusMessage":
+        # Format: type(1) + status(1) + timestamp(8) + symbol(8)
+        status, timestamp, symbol = struct.unpack("<xbq8s", data[:18])
+        return cls(
+            operational_halt_status=bytes([status]),
+            timestamp=timestamp,
+            symbol=symbol,
+        )
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "<cbq8s",
+            self.message_type,
+            self.operational_halt_status[0],
+            self.timestamp,
+            self.symbol,
+        )
+
+    def _add_json_fields(self, d: dict[str, Any]) -> None:
+        d["operational_halt_status"] = self.operational_halt_status.decode("ascii")
+        d["symbol"] = self.symbol.decode("ascii").strip()
+
+
+class ShortSalePriceTestStatusMessage(IEXDEEPMarketMessage):
+    """Short Sale Price Test Status Message (P, 0x50).
+
+    Indicates Reg SHO short sale price test restriction status.
+    Total message length: 19 bytes.
+
+    Status:
+    - 0 (0x0): Short Sale Price Test Not in Effect
+    - 1 (0x1): Short Sale Price Test in Effect
+
+    Detail:
+    - ' ' (0x20): No price test in place
+    - 'A' (0x41): Activated
+    - 'C' (0x43): Continued
+    - 'D' (0x44): Deactivated
+    - 'N' (0x4e): Detail Not Available
+    """
+
+    message_type = b"P"
+    message_length = 19
+
+    def __init__(
+        self,
+        short_sale_price_test_status: int,
+        timestamp: int,
+        symbol: bytes,
+        detail: bytes,
+    ) -> None:
+        super().__init__(timestamp)
+        self.short_sale_price_test_status = short_sale_price_test_status
+        self.symbol = symbol
+        self.detail = detail
+
+    @classmethod
+    def _from_bytes(cls, data: bytes) -> "ShortSalePriceTestStatusMessage":
+        # Format: type(1) + status(1) + timestamp(8) + symbol(8) + detail(1)
+        status, timestamp, symbol, detail = struct.unpack("<xBq8sb", data[:19])
+        return cls(
+            short_sale_price_test_status=status,
+            timestamp=timestamp,
+            symbol=symbol,
+            detail=bytes([detail]),
+        )
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "<cBq8sb",
+            self.message_type,
+            self.short_sale_price_test_status,
+            self.timestamp,
+            self.symbol,
+            self.detail[0],
+        )
+
+    def _add_json_fields(self, d: dict[str, Any]) -> None:
+        d["short_sale_price_test_status"] = self.short_sale_price_test_status
+        d["symbol"] = self.symbol.decode("ascii").strip()
+        d["detail"] = self.detail.decode("ascii")
+
+
+class SecurityEventMessage(IEXDEEPMarketMessage):
+    """Security Event Message (E, 0x45).
+
+    Indicates events that apply to a security.
+    Total message length: 18 bytes.
+
+    Security Events:
+    - 'O' (0x4f): Opening Process Complete
+    - 'C' (0x43): Closing Process Complete
+    """
+
+    message_type = b"E"
+    message_length = 18
+
+    def __init__(
+        self,
+        security_event: bytes,
+        timestamp: int,
+        symbol: bytes,
+    ) -> None:
+        super().__init__(timestamp)
+        self.security_event = security_event
+        self.symbol = symbol
+
+    @classmethod
+    def _from_bytes(cls, data: bytes) -> "SecurityEventMessage":
+        # Format: type(1) + event(1) + timestamp(8) + symbol(8)
+        event, timestamp, symbol = struct.unpack("<xbq8s", data[:18])
+        return cls(
+            security_event=bytes([event]),
+            timestamp=timestamp,
+            symbol=symbol,
+        )
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "<cbq8s",
+            self.message_type,
+            self.security_event[0],
+            self.timestamp,
+            self.symbol,
+        )
+
+    def _add_json_fields(self, d: dict[str, Any]) -> None:
+        d["security_event"] = self.security_event.decode("ascii")
+        d["symbol"] = self.symbol.decode("ascii").strip()
+
+
+class PriceLevelUpdateMessage(IEXDEEPMarketMessage):
+    """Base class for Price Level Update Messages.
+
+    Price level updates provide aggregated size at a price level.
+    Total message length: 30 bytes.
+
+    Event Flags:
+    - 0 (0x0): Order Book is processing (in transition)
+    - 1 (0x1): Event processing complete
+    """
+
+    message_length = 30
+
+    def __init__(
+        self,
+        event_flags: int,
+        timestamp: int,
+        symbol: bytes,
+        size: int,
+        price: int,
+    ) -> None:
+        super().__init__(timestamp)
+        self.event_flags = event_flags
+        self.symbol = symbol
+        self.size = size
+        self.price = price
+
+    @classmethod
+    def _from_bytes(cls, data: bytes) -> "PriceLevelUpdateMessage":
+        # Format: type(1) + flags(1) + timestamp(8) + symbol(8) + size(4) + price(8)
+        event_flags, timestamp, symbol, size, price = struct.unpack(
+            "<xBq8sIq", data[:30]
+        )
+        return cls(
+            event_flags=event_flags,
+            timestamp=timestamp,
+            symbol=symbol,
+            size=size,
+            price=price,
+        )
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "<cBq8sIq",
+            self.message_type,
+            self.event_flags,
+            self.timestamp,
+            self.symbol,
+            self.size,
+            self.price,
+        )
+
+    def _add_json_fields(self, d: dict[str, Any]) -> None:
+        d["event_flags"] = self.event_flags
+        d["symbol"] = self.symbol.decode("ascii").strip()
+        d["size"] = self.size
+        d["price"] = self.price / 10000.0
+
+    @property
+    def is_event_complete(self) -> bool:
+        """Check if this update completes an atomic event."""
+        return self.event_flags == 1
+
+
+class PriceLevelUpdateBuySideMessage(PriceLevelUpdateMessage):
+    """Price Level Update on the Buy Side (8, 0x38)."""
+
+    message_type = b"8"
+
+
+class PriceLevelUpdateSellSideMessage(PriceLevelUpdateMessage):
+    """Price Level Update on the Sell Side (5, 0x35)."""
+
+    message_type = b"5"
+
+
+class TradeReportMessage(IEXDEEPMarketMessage):
+    """Trade Report Message (T, 0x54).
+
+    Sent when an order on IEX is executed.
+    Total message length: 38 bytes.
+
+    Sale Condition Flags (bits):
+    - Bit 7: Intermarket Sweep (ISO)
+    - Bit 6: Extended Hours (Form T)
+    - Bit 5: Odd Lot
+    - Bit 4: Trade Through Exempt
+    - Bit 3: Single-price Cross Trade
+    """
+
+    message_type = b"T"
+    message_length = 38
+
+    def __init__(
+        self,
+        sale_condition_flags: int,
+        timestamp: int,
+        symbol: bytes,
+        size: int,
+        price: int,
+        trade_id: int,
+    ) -> None:
+        super().__init__(timestamp)
+        self.sale_condition_flags = sale_condition_flags
+        self.symbol = symbol
+        self.size = size
+        self.price = price
+        self.trade_id = trade_id
+
+    @classmethod
+    def _from_bytes(cls, data: bytes) -> "TradeReportMessage":
+        # Format: type(1) + flags(1) + timestamp(8) + symbol(8) + size(4) + price(8) + trade_id(8)
+        flags, timestamp, symbol, size, price, trade_id = struct.unpack(
+            "<xBq8sIqq", data[:38]
+        )
+        return cls(
+            sale_condition_flags=flags,
+            timestamp=timestamp,
+            symbol=symbol,
+            size=size,
+            price=price,
+            trade_id=trade_id,
+        )
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "<cBq8sIqq",
+            self.message_type,
+            self.sale_condition_flags,
+            self.timestamp,
+            self.symbol,
+            self.size,
+            self.price,
+            self.trade_id,
+        )
+
+    def _add_json_fields(self, d: dict[str, Any]) -> None:
+        d["sale_condition_flags"] = self.sale_condition_flags
+        d["symbol"] = self.symbol.decode("ascii").strip()
+        d["size"] = self.size
+        d["price"] = self.price / 10000.0
+        d["trade_id"] = self.trade_id
+
+    @property
+    def is_intermarket_sweep(self) -> bool:
+        """Check if trade resulted from an ISO."""
+        return bool(self.sale_condition_flags & 0x80)
+
+    @property
+    def is_extended_hours(self) -> bool:
+        """Check if trade occurred outside regular market session."""
+        return bool(self.sale_condition_flags & 0x40)
+
+    @property
+    def is_odd_lot(self) -> bool:
+        """Check if trade is less than one round lot."""
+        return bool(self.sale_condition_flags & 0x20)
+
+    @property
+    def is_trade_through_exempt(self) -> bool:
+        """Check if trade is exempt from Rule 611."""
+        return bool(self.sale_condition_flags & 0x10)
+
+    @property
+    def is_single_price_cross(self) -> bool:
+        """Check if trade resulted from a single-price cross."""
+        return bool(self.sale_condition_flags & 0x08)
+
+
+class OfficialPriceMessage(IEXDEEPMarketMessage):
+    """Official Price Message (X, 0x58).
+
+    Indicates IEX Official Opening or Closing Price.
+    Total message length: 26 bytes.
+
+    Price Type:
+    - 'Q' (0x51): IEX Official Opening Price
+    - 'M' (0x4d): IEX Official Closing Price
+    """
+
+    message_type = b"X"
+    message_length = 26
+
+    def __init__(
+        self,
+        price_type: bytes,
+        timestamp: int,
+        symbol: bytes,
+        official_price: int,
+    ) -> None:
+        super().__init__(timestamp)
+        self.price_type = price_type
+        self.symbol = symbol
+        self.official_price = official_price
+
+    @classmethod
+    def _from_bytes(cls, data: bytes) -> "OfficialPriceMessage":
+        # Format: type(1) + price_type(1) + timestamp(8) + symbol(8) + price(8)
+        price_type, timestamp, symbol, price = struct.unpack("<xbq8sq", data[:26])
+        return cls(
+            price_type=bytes([price_type]),
+            timestamp=timestamp,
+            symbol=symbol,
+            official_price=price,
+        )
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "<cbq8sq",
+            self.message_type,
+            self.price_type[0],
+            self.timestamp,
+            self.symbol,
+            self.official_price,
+        )
+
+    def _add_json_fields(self, d: dict[str, Any]) -> None:
+        d["price_type"] = self.price_type.decode("ascii")
+        d["symbol"] = self.symbol.decode("ascii").strip()
+        d["official_price"] = self.official_price / 10000.0
+
+
+class TradeBreakMessage(IEXDEEPMarketMessage):
+    """Trade Break Message (B, 0x42).
+
+    Sent when an execution on IEX is broken.
+    Total message length: 38 bytes.
+    """
+
+    message_type = b"B"
+    message_length = 38
+
+    def __init__(
+        self,
+        sale_condition_flags: int,
+        timestamp: int,
+        symbol: bytes,
+        size: int,
+        price: int,
+        trade_id: int,
+    ) -> None:
+        super().__init__(timestamp)
+        self.sale_condition_flags = sale_condition_flags
+        self.symbol = symbol
+        self.size = size
+        self.price = price
+        self.trade_id = trade_id
+
+    @classmethod
+    def _from_bytes(cls, data: bytes) -> "TradeBreakMessage":
+        # Format: type(1) + flags(1) + timestamp(8) + symbol(8) + size(4) + price(8) + trade_id(8)
+        flags, timestamp, symbol, size, price, trade_id = struct.unpack(
+            "<xBq8sIqq", data[:38]
+        )
+        return cls(
+            sale_condition_flags=flags,
+            timestamp=timestamp,
+            symbol=symbol,
+            size=size,
+            price=price,
+            trade_id=trade_id,
+        )
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "<cBq8sIqq",
+            self.message_type,
+            self.sale_condition_flags,
+            self.timestamp,
+            self.symbol,
+            self.size,
+            self.price,
+            self.trade_id,
+        )
+
+    def _add_json_fields(self, d: dict[str, Any]) -> None:
+        d["sale_condition_flags"] = self.sale_condition_flags
+        d["symbol"] = self.symbol.decode("ascii").strip()
+        d["size"] = self.size
+        d["price"] = self.price / 10000.0
+        d["trade_id"] = self.trade_id
+
+
+class AuctionInformationMessage(IEXDEEPMarketMessage):
+    """Auction Information Message (A, 0x41).
+
+    Provides auction information for IEX-listed securities.
+    Total message length: 80 bytes.
+
+    Auction Type:
+    - 'O' (0x4f): Opening Auction
+    - 'C' (0x43): Closing Auction
+    - 'I' (0x49): IPO Auction
+    - 'H' (0x48): Halt Auction
+    - 'V' (0x56): Volatility Auction
+
+    Imbalance Side:
+    - 'B' (0x42): Buy-side imbalance
+    - 'S' (0x53): Sell-side imbalance
+    - 'N' (0x4e): No imbalance
+    """
+
+    message_type = b"A"
+    message_length = 80
+
+    def __init__(
+        self,
+        auction_type: bytes,
+        timestamp: int,
+        symbol: bytes,
+        paired_shares: int,
+        reference_price: int,
+        indicative_clearing_price: int,
+        imbalance_shares: int,
+        imbalance_side: bytes,
+        extension_number: int,
+        scheduled_auction_time: int,
+        auction_book_clearing_price: int,
+        collar_reference_price: int,
+        lower_auction_collar: int,
+        upper_auction_collar: int,
+    ) -> None:
+        super().__init__(timestamp)
+        self.auction_type = auction_type
+        self.symbol = symbol
+        self.paired_shares = paired_shares
+        self.reference_price = reference_price
+        self.indicative_clearing_price = indicative_clearing_price
+        self.imbalance_shares = imbalance_shares
+        self.imbalance_side = imbalance_side
+        self.extension_number = extension_number
+        self.scheduled_auction_time = scheduled_auction_time
+        self.auction_book_clearing_price = auction_book_clearing_price
+        self.collar_reference_price = collar_reference_price
+        self.lower_auction_collar = lower_auction_collar
+        self.upper_auction_collar = upper_auction_collar
+
+    @classmethod
+    def _from_bytes(cls, data: bytes) -> "AuctionInformationMessage":
+        # Format: type(1) + auction_type(1) + timestamp(8) + symbol(8) +
+        #         paired_shares(4) + reference_price(8) + indicative_clearing_price(8) +
+        #         imbalance_shares(4) + imbalance_side(1) + extension_number(1) +
+        #         scheduled_auction_time(4) + auction_book_clearing_price(8) +
+        #         collar_reference_price(8) + lower_auction_collar(8) + upper_auction_collar(8)
+        (
+            auction_type,
+            timestamp,
+            symbol,
+            paired_shares,
+            reference_price,
+            indicative_clearing_price,
+            imbalance_shares,
+            imbalance_side,
+            extension_number,
+            scheduled_auction_time,
+            auction_book_clearing_price,
+            collar_reference_price,
+            lower_auction_collar,
+            upper_auction_collar,
+        ) = struct.unpack("<xbq8sIqqIbBIqqqq", data[:80])
+        return cls(
+            auction_type=bytes([auction_type]),
+            timestamp=timestamp,
+            symbol=symbol,
+            paired_shares=paired_shares,
+            reference_price=reference_price,
+            indicative_clearing_price=indicative_clearing_price,
+            imbalance_shares=imbalance_shares,
+            imbalance_side=bytes([imbalance_side]),
+            extension_number=extension_number,
+            scheduled_auction_time=scheduled_auction_time,
+            auction_book_clearing_price=auction_book_clearing_price,
+            collar_reference_price=collar_reference_price,
+            lower_auction_collar=lower_auction_collar,
+            upper_auction_collar=upper_auction_collar,
+        )
+
+    def to_bytes(self) -> bytes:
+        return struct.pack(
+            "<cbq8sIqqIbBIqqqq",
+            self.message_type,
+            self.auction_type[0],
+            self.timestamp,
+            self.symbol,
+            self.paired_shares,
+            self.reference_price,
+            self.indicative_clearing_price,
+            self.imbalance_shares,
+            self.imbalance_side[0],
+            self.extension_number,
+            self.scheduled_auction_time,
+            self.auction_book_clearing_price,
+            self.collar_reference_price,
+            self.lower_auction_collar,
+            self.upper_auction_collar,
+        )
+
+    def _add_json_fields(self, d: dict[str, Any]) -> None:
+        d["auction_type"] = self.auction_type.decode("ascii")
+        d["symbol"] = self.symbol.decode("ascii").strip()
+        d["paired_shares"] = self.paired_shares
+        d["reference_price"] = self.reference_price / 10000.0
+        d["indicative_clearing_price"] = self.indicative_clearing_price / 10000.0
+        d["imbalance_shares"] = self.imbalance_shares
+        d["imbalance_side"] = self.imbalance_side.decode("ascii")
+        d["extension_number"] = self.extension_number
+        d["scheduled_auction_time"] = self.scheduled_auction_time
+        d["auction_book_clearing_price"] = self.auction_book_clearing_price / 10000.0
+        d["collar_reference_price"] = self.collar_reference_price / 10000.0
+        d["lower_auction_collar"] = self.lower_auction_collar / 10000.0
+        d["upper_auction_collar"] = self.upper_auction_collar / 10000.0

--- a/src/meatpy/iex_deep/iex_deep_market_processor.py
+++ b/src/meatpy/iex_deep/iex_deep_market_processor.py
@@ -1,0 +1,474 @@
+"""IEX DEEP market processor for price level-based order book reconstruction.
+
+This module provides the IEXDEEPMarketProcessor class, which processes IEX DEEP
+market messages to reconstruct the limit order book based on price level updates.
+
+Unlike ITCH 5.0 which provides individual orders, IEX DEEP provides aggregated
+price level updates, so the processor works with price levels directly.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Optional
+
+from ..lob import LimitOrderBook, OrderType
+from ..market_processor import MarketProcessor
+from ..message_reader import MarketMessage
+from ..timestamp import Timestamp
+from ..trading_status import (
+    HaltedTradingStatus,
+    PostTradeTradingStatus,
+    PreTradeTradingStatus,
+    TradeTradingStatus,
+)
+from ..types import Price, TradeRef, Volume
+from .iex_deep_market_message import (
+    AuctionInformationMessage,
+    IEXDEEPMarketMessage,
+    OperationalHaltStatusMessage,
+    OfficialPriceMessage,
+    PriceLevelUpdateBuySideMessage,
+    PriceLevelUpdateSellSideMessage,
+    SecurityDirectoryMessage,
+    SecurityEventMessage,
+    ShortSalePriceTestStatusMessage,
+    SystemEventMessage,
+    TradeBreakMessage,
+    TradeReportMessage,
+    TradingStatusMessage,
+)
+
+
+class InvalidMessageTypeError(Exception):
+    """Exception raised when an invalid message type is encountered."""
+
+    pass
+
+
+class IEXDEEPMarketProcessor(MarketProcessor[int, int, int, int, dict[str, str]]):
+    """A market processor for IEX DEEP format.
+
+    This processor handles IEX DEEP market messages and reconstructs the limit
+    order book based on price level updates. Unlike ITCH 5.0, IEX DEEP provides
+    aggregated price levels directly rather than individual orders.
+
+    Attributes:
+        system_status: Current system event status
+        trading_status_code: Current trading status code for the instrument
+        operational_halt_status: Current operational halt status
+        short_sale_status: Current short sale price test status
+    """
+
+    def __init__(
+        self,
+        instrument: str | bytes,
+        book_date: Optional[datetime.datetime] = None,
+        track_lob: bool = False,
+    ) -> None:
+        """Initialize the IEXDEEPMarketProcessor.
+
+        Args:
+            instrument: The instrument/symbol to process (8 chars, space-padded)
+            book_date: The trading date for this processor (optional for IEX DEEP
+                       since timestamps are absolute)
+            track_lob: Whether to track the full LOB (default False for IEX DEEP
+                       since it uses price-level data, not individual orders)
+        """
+        # book_date is optional for IEX DEEP since timestamps are POSIX epoch
+        if book_date is None:
+            book_date = datetime.datetime.now(datetime.timezone.utc)
+
+        super(IEXDEEPMarketProcessor, self).__init__(instrument, book_date)
+        # IEX DEEP doesn't use order-level LOB tracking by default
+        self.track_lob = track_lob
+
+        # Override instrument to store as bytes with proper formatting
+        self.instrument: bytes = (
+            f"{instrument:<8}".encode("ascii")
+            if isinstance(instrument, str)
+            else instrument
+        )
+        self.book_date: datetime.datetime = book_date
+        self.system_status: bytes = b""
+        self.trading_status_code: bytes = b""
+        self.operational_halt_status: bytes = b""
+        self.short_sale_status: int = 0
+
+        self._trade_ids: set[int] = set()
+        # Track price levels: {price: size}
+        self._bid_levels: dict[int, int] = {}
+        self._ask_levels: dict[int, int] = {}
+
+    def adjust_timestamp(self, raw_timestamp: int) -> Timestamp:
+        """Convert raw timestamp to a Timestamp object.
+
+        IEX DEEP timestamps are nanoseconds since POSIX epoch UTC.
+
+        Args:
+            raw_timestamp: The raw timestamp in nanoseconds since POSIX epoch
+
+        Returns:
+            A Timestamp object representing the adjusted time
+        """
+        # Convert nanoseconds since POSIX epoch to datetime
+        seconds = raw_timestamp // 1_000_000_000
+        nanoseconds = raw_timestamp % 1_000_000_000
+        dt = datetime.datetime.fromtimestamp(seconds, tz=datetime.timezone.utc)
+        dt = dt.replace(microsecond=nanoseconds // 1000)
+        return Timestamp.from_datetime(dt)
+
+    def process_message(
+        self, message: MarketMessage, new_snapshot: bool = True
+    ) -> None:
+        """Process an IEX DEEP market message.
+
+        Args:
+            message: The market message to process
+            new_snapshot: Whether to create a new LOB snapshot
+        """
+        if not isinstance(message, IEXDEEPMarketMessage):
+            raise InvalidMessageTypeError(
+                f"Message is not an IEXDEEPMarketMessage: {type(message)}"
+            )
+
+        timestamp = self.adjust_timestamp(message.timestamp)
+        self.message_event(timestamp, message)
+
+        if isinstance(message, SystemEventMessage):
+            self.process_system_message(message, timestamp, new_snapshot)
+
+        elif isinstance(message, SecurityDirectoryMessage):
+            # Security directory - only process for our instrument
+            if message.symbol != self.instrument:
+                return
+            # Store security info if needed
+            pass
+
+        elif isinstance(message, TradingStatusMessage):
+            if message.symbol != self.instrument:
+                return
+            self.process_trading_status_message(message, timestamp, new_snapshot)
+
+        elif isinstance(message, OperationalHaltStatusMessage):
+            if message.symbol != self.instrument:
+                return
+            self.process_operational_halt_message(message, timestamp, new_snapshot)
+
+        elif isinstance(message, ShortSalePriceTestStatusMessage):
+            if message.symbol != self.instrument:
+                return
+            self.short_sale_status = message.short_sale_price_test_status
+
+        elif isinstance(message, SecurityEventMessage):
+            if message.symbol != self.instrument:
+                return
+            # Security events (opening/closing complete) - can trigger status updates
+            pass
+
+        elif isinstance(message, PriceLevelUpdateBuySideMessage):
+            if message.symbol != self.instrument:
+                return
+            self.update_price_level(
+                timestamp=timestamp,
+                price=message.price,
+                size=message.size,
+                side=OrderType.BID,
+            )
+
+        elif isinstance(message, PriceLevelUpdateSellSideMessage):
+            if message.symbol != self.instrument:
+                return
+            self.update_price_level(
+                timestamp=timestamp,
+                price=message.price,
+                size=message.size,
+                side=OrderType.ASK,
+            )
+
+        elif isinstance(message, TradeReportMessage):
+            if message.symbol != self.instrument:
+                return
+            self._trade_ids.add(message.trade_id)
+            self.trade_event(
+                timestamp=timestamp,
+                price=message.price,
+                volume=message.size,
+                trade_ref=message.trade_id,
+            )
+
+        elif isinstance(message, TradeBreakMessage):
+            if message.symbol != self.instrument:
+                return
+            # Trade break - remove from trade set if present
+            self._trade_ids.discard(message.trade_id)
+            self.trade_break_event(
+                timestamp=timestamp,
+                price=message.price,
+                volume=message.size,
+                trade_ref=message.trade_id,
+            )
+
+        elif isinstance(message, OfficialPriceMessage):
+            if message.symbol != self.instrument:
+                return
+            self.official_price_event(
+                timestamp=timestamp,
+                price_type=message.price_type,
+                price=message.official_price,
+            )
+
+        elif isinstance(message, AuctionInformationMessage):
+            if message.symbol != self.instrument:
+                return
+            self.auction_event(timestamp=timestamp, message=message)
+
+    def process_system_message(
+        self,
+        message: SystemEventMessage,
+        timestamp: Timestamp,
+        new_snapshot: bool = True,
+    ) -> None:
+        """Process a system event message.
+
+        Args:
+            message: The system event message
+            timestamp: The timestamp of the event
+            new_snapshot: Whether to create a new LOB snapshot
+        """
+        self.system_status = message.system_event
+        self.update_trading_status()
+
+    def process_trading_status_message(
+        self,
+        message: TradingStatusMessage,
+        timestamp: Timestamp,
+        new_snapshot: bool = True,
+    ) -> None:
+        """Process a trading status message.
+
+        Args:
+            message: The trading status message
+            timestamp: The timestamp of the event
+            new_snapshot: Whether to create a new LOB snapshot
+        """
+        self.trading_status_code = message.trading_status
+        self.update_trading_status()
+
+    def process_operational_halt_message(
+        self,
+        message: OperationalHaltStatusMessage,
+        timestamp: Timestamp,
+        new_snapshot: bool = True,
+    ) -> None:
+        """Process an operational halt status message.
+
+        Args:
+            message: The operational halt status message
+            timestamp: The timestamp of the event
+            new_snapshot: Whether to create a new LOB snapshot
+        """
+        self.operational_halt_status = message.operational_halt_status
+        self.update_trading_status()
+
+    def update_trading_status(self) -> None:
+        """Update the current trading status based on system and trading status."""
+        # Check for operational halt first
+        if self.operational_halt_status == b"O":
+            self.trading_status = HaltedTradingStatus()
+            return
+
+        # Check trading status
+        if self.trading_status_code == b"H":
+            self.trading_status = HaltedTradingStatus()
+        elif self.trading_status_code == b"P":
+            # Trading paused - treat as halted
+            self.trading_status = HaltedTradingStatus()
+        elif self.trading_status_code == b"O":
+            # Order acceptance period - pre-trade
+            self.trading_status = PreTradeTradingStatus()
+        elif self.trading_status_code == b"T":
+            self.trading_status = TradeTradingStatus()
+        elif self.system_status in (b"O", b"S"):
+            # Start of messages or start of system hours
+            self.trading_status = PreTradeTradingStatus()
+        elif self.system_status in (b"M", b"E", b"C"):
+            # End of regular market hours, end of system hours, end of messages
+            self.trading_status = PostTradeTradingStatus()
+        elif self.system_status == b"R":
+            # Start of regular market hours
+            self.trading_status = TradeTradingStatus()
+
+    def update_price_level(
+        self,
+        timestamp: Timestamp,
+        price: Price,
+        size: Volume,
+        side: OrderType,
+    ) -> None:
+        """Update a price level in the order book.
+
+        For IEX DEEP, we receive the new total size at each price level.
+        A size of 0 means the price level should be removed.
+
+        Args:
+            timestamp: The timestamp of the update
+            price: The price level
+            size: The new total size at this price level
+            side: BID or ASK
+        """
+        # Update internal tracking
+        if side == OrderType.BID:
+            if size == 0:
+                self._bid_levels.pop(price, None)
+            else:
+                self._bid_levels[price] = size
+        else:
+            if size == 0:
+                self._ask_levels.pop(price, None)
+            else:
+                self._ask_levels[price] = size
+
+        # Fire event for handlers
+        self.price_level_update_event(timestamp, price, size, side)
+
+    def trade_event(
+        self,
+        timestamp: Timestamp,
+        price: Price,
+        volume: Volume,
+        trade_ref: TradeRef,
+    ) -> None:
+        """Record a trade event.
+
+        Args:
+            timestamp: The timestamp of the trade
+            price: The trade price
+            volume: The trade volume
+            trade_ref: The trade reference ID
+        """
+        # Fire trade event to handlers
+        for handler in self.handlers:
+            if hasattr(handler, "on_trade"):
+                handler.on_trade(timestamp, price, volume, trade_ref)
+
+    def trade_break_event(
+        self,
+        timestamp: Timestamp,
+        price: Price,
+        volume: Volume,
+        trade_ref: TradeRef,
+    ) -> None:
+        """Record a trade break event.
+
+        Args:
+            timestamp: The timestamp of the trade break
+            price: The trade price
+            volume: The trade volume
+            trade_ref: The trade reference ID
+        """
+        # Fire trade break event to handlers
+        for handler in self.handlers:
+            if hasattr(handler, "on_trade_break"):
+                handler.on_trade_break(timestamp, price, volume, trade_ref)
+
+    def official_price_event(
+        self,
+        timestamp: Timestamp,
+        price_type: bytes,
+        price: Price,
+    ) -> None:
+        """Record an official price event.
+
+        Args:
+            timestamp: The timestamp of the official price
+            price_type: 'Q' for opening, 'M' for closing
+            price: The official price
+        """
+        # Fire official price event to handlers
+        for handler in self.handlers:
+            if hasattr(handler, "on_official_price"):
+                handler.on_official_price(timestamp, price_type, price)
+
+    def auction_event(
+        self,
+        timestamp: Timestamp,
+        message: AuctionInformationMessage,
+    ) -> None:
+        """Record an auction information event.
+
+        Args:
+            timestamp: The timestamp of the auction info
+            message: The auction information message
+        """
+        # Fire auction event to handlers
+        for handler in self.handlers:
+            if hasattr(handler, "on_auction"):
+                handler.on_auction(timestamp, message)
+
+    def price_level_update_event(
+        self,
+        timestamp: Timestamp,
+        price: Price,
+        size: Volume,
+        side: OrderType,
+    ) -> None:
+        """Fire a price level update event to handlers.
+
+        Args:
+            timestamp: The timestamp of the update
+            price: The price level
+            size: The new size at this level
+            side: BID or ASK
+        """
+        for handler in self.handlers:
+            if hasattr(handler, "on_price_level_update"):
+                handler.on_price_level_update(timestamp, price, size, side)
+
+    def create_lob(self, timestamp: Timestamp) -> None:
+        """Create a new limit order book.
+
+        Args:
+            timestamp: The timestamp for the new limit order book
+        """
+        super().create_lob(timestamp)
+        if isinstance(self.current_lob, LimitOrderBook):
+            # IEX DEEP prices have 4 decimal places (divide by 10000)
+            self.current_lob.decimals_adj = 10000
+        else:
+            raise RuntimeError(
+                "IEXDEEPMarketProcessor:create_lob",
+                "Post-creation LOB is not a LimitOrderBook instance.",
+            )
+
+    def get_best_bid(self) -> tuple[Price, Volume] | None:
+        """Get the best bid price and size.
+
+        Returns:
+            Tuple of (price, size) or None if no bids
+        """
+        if not self._bid_levels:
+            return None
+        best_price = max(self._bid_levels.keys())
+        return (best_price, self._bid_levels[best_price])
+
+    def get_best_ask(self) -> tuple[Price, Volume] | None:
+        """Get the best ask price and size.
+
+        Returns:
+            Tuple of (price, size) or None if no asks
+        """
+        if not self._ask_levels:
+            return None
+        best_price = min(self._ask_levels.keys())
+        return (best_price, self._ask_levels[best_price])
+
+    def get_bbo(
+        self,
+    ) -> tuple[tuple[Price, Volume] | None, tuple[Price, Volume] | None]:
+        """Get the best bid and offer.
+
+        Returns:
+            Tuple of (best_bid, best_ask) where each is (price, size) or None
+        """
+        return (self.get_best_bid(), self.get_best_ask())

--- a/src/meatpy/iex_deep/iex_deep_message_reader.py
+++ b/src/meatpy/iex_deep/iex_deep_message_reader.py
@@ -1,0 +1,325 @@
+"""IEX DEEP PCAP file reader with generator interface.
+
+This module provides the IEXDEEPMessageReader class, which reads IEX DEEP market data
+from PCAP and PCAP-NG files and yields structured message objects one at a time.
+
+IEX DEEP data is delivered via IEX Transport Protocol (IEX-TP) encapsulated in PCAP format.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+from typing import Generator, Optional
+
+from ..message_reader import InvalidMessageFormatError, MessageReader
+from .iex_deep_market_message import IEXDEEPMarketMessage
+
+
+# PCAP file format constants
+PCAP_MAGIC_NUMBER = 0xA1B2C3D4  # Standard pcap magic (microsecond resolution)
+PCAP_MAGIC_NUMBER_NS = 0xA1B23C4D  # Nanosecond resolution pcap magic
+PCAP_MAGIC_NUMBER_SWAPPED = 0xD4C3B2A1  # Byte-swapped standard
+PCAP_MAGIC_NUMBER_NS_SWAPPED = 0x4D3CB2A1  # Byte-swapped nanosecond
+PCAP_GLOBAL_HEADER_SIZE = 24
+PCAP_PACKET_HEADER_SIZE = 16
+
+# PCAP-NG format constants
+PCAPNG_SECTION_HEADER_BLOCK = 0x0A0D0D0A
+PCAPNG_INTERFACE_DESC_BLOCK = 0x00000001
+PCAPNG_ENHANCED_PACKET_BLOCK = 0x00000006
+PCAPNG_SIMPLE_PACKET_BLOCK = 0x00000003
+
+# IEX-TP constants
+IEX_TP_HEADER_SIZE = 40
+IEX_DEEP_MESSAGE_PROTOCOL_ID = 0x8004
+
+
+class IEXDEEPMessageReader(MessageReader):
+    """A market message reader for IEX DEEP data in PCAP/PCAP-NG format.
+
+    This reader reads IEX DEEP PCAP or PCAP-NG files and yields message objects
+    one at a time, supporting automatic detection of compressed files
+    (gzip, bzip2, xz, zip).
+
+    The PCAP files contain IEX-TP transport protocol packets with IEX DEEP messages.
+
+    Attributes:
+        file_path: Path to the PCAP file to read
+        _file_handle: Internal file handle when used as context manager
+    """
+
+    def __init__(
+        self,
+        file_path: Optional[Path | str] = None,
+    ) -> None:
+        """Initialize the IEXDEEPMessageReader.
+
+        Args:
+            file_path: Path to the PCAP file to read (optional if using read_file method)
+        """
+        super().__init__(file_path)
+
+    def __iter__(self) -> Generator[IEXDEEPMarketMessage, None, None]:
+        """Make the reader iterable when used as a context manager."""
+        if self._file_handle is None:
+            raise RuntimeError(
+                "Reader must be used as a context manager to be iterable"
+            )
+        yield from self._read_messages(self._file_handle)
+
+    def read_file(
+        self, file_path: Path | str
+    ) -> Generator[IEXDEEPMarketMessage, None, None]:
+        """Parse an IEX DEEP PCAP file and yield messages one at a time.
+
+        Args:
+            file_path: Path to the PCAP file to read
+
+        Yields:
+            IEXDEEPMarketMessage objects
+        """
+        file_path = Path(file_path)
+        with self._open_file(file_path) as file:
+            yield from self._read_messages(file)
+
+    def _read_messages(self, file) -> Generator[IEXDEEPMarketMessage, None, None]:
+        """Internal method to read messages from an open file handle.
+
+        Args:
+            file: Open file handle to read from
+
+        Yields:
+            IEXDEEPMarketMessage objects
+        """
+        # Read first 4 bytes to determine file format
+        magic_bytes = file.read(4)
+        if len(magic_bytes) < 4:
+            raise InvalidMessageFormatError("File too short")
+
+        magic_number = struct.unpack("<I", magic_bytes)[0]
+
+        # Check for PCAP-NG format (Section Header Block)
+        if magic_number == PCAPNG_SECTION_HEADER_BLOCK:
+            # Seek back and read as PCAP-NG
+            file.seek(0)
+            yield from self._read_pcapng(file)
+        elif magic_number in (
+            PCAP_MAGIC_NUMBER,
+            PCAP_MAGIC_NUMBER_NS,
+            PCAP_MAGIC_NUMBER_SWAPPED,
+            PCAP_MAGIC_NUMBER_NS_SWAPPED,
+        ):
+            # Seek back and read as standard PCAP
+            file.seek(0)
+            yield from self._read_pcap(file)
+        else:
+            raise InvalidMessageFormatError(
+                f"Unknown file format, magic number: {magic_number:#x}"
+            )
+
+    def _read_pcap(self, file) -> Generator[IEXDEEPMarketMessage, None, None]:
+        """Read standard PCAP format.
+
+        Args:
+            file: Open file handle
+
+        Yields:
+            IEXDEEPMarketMessage objects
+        """
+        # Read global header
+        global_header = file.read(PCAP_GLOBAL_HEADER_SIZE)
+        if len(global_header) < PCAP_GLOBAL_HEADER_SIZE:
+            raise InvalidMessageFormatError("PCAP file too short for global header")
+
+        magic_number = struct.unpack("<I", global_header[0:4])[0]
+
+        # Determine byte order
+        if magic_number in (PCAP_MAGIC_NUMBER, PCAP_MAGIC_NUMBER_NS):
+            byte_order = "<"
+        else:
+            byte_order = ">"
+
+        # Read packets
+        while True:
+            packet_header = file.read(PCAP_PACKET_HEADER_SIZE)
+            if len(packet_header) < PCAP_PACKET_HEADER_SIZE:
+                break
+
+            ts_sec, ts_usec, incl_len, orig_len = struct.unpack(
+                f"{byte_order}IIII", packet_header
+            )
+
+            packet_data = file.read(incl_len)
+            if len(packet_data) < incl_len:
+                break
+
+            yield from self._parse_packet(packet_data)
+
+    def _read_pcapng(self, file) -> Generator[IEXDEEPMarketMessage, None, None]:
+        """Read PCAP-NG format.
+
+        Args:
+            file: Open file handle
+
+        Yields:
+            IEXDEEPMarketMessage objects
+        """
+        byte_order = "<"  # Will be determined from Section Header Block
+
+        while True:
+            # Read block header: type(4) + length(4)
+            block_header = file.read(8)
+            if len(block_header) < 8:
+                break
+
+            block_type, block_length = struct.unpack(f"{byte_order}II", block_header)
+
+            # Handle Section Header Block (determines byte order)
+            if block_type == PCAPNG_SECTION_HEADER_BLOCK:
+                # Read the rest of the minimum block (need byte order magic)
+                # Block: type(4) + length(4) + byte_order_magic(4) + version(4) + section_len(8)
+                shb_data = file.read(block_length - 8)
+                if len(shb_data) < 12:
+                    break
+
+                byte_order_magic = struct.unpack("<I", shb_data[0:4])[0]
+                if byte_order_magic == 0x1A2B3C4D:
+                    byte_order = "<"
+                elif byte_order_magic == 0x4D3C2B1A:
+                    byte_order = ">"
+                continue
+
+            # Read the rest of the block
+            remaining = block_length - 8
+            if remaining <= 0:
+                continue
+
+            block_data = file.read(remaining)
+            if len(block_data) < remaining:
+                break
+
+            # Handle Enhanced Packet Block
+            if block_type == PCAPNG_ENHANCED_PACKET_BLOCK:
+                # EPB format: interface_id(4) + timestamp_high(4) + timestamp_low(4) +
+                #             captured_len(4) + original_len(4) + packet_data + padding + block_length(4)
+                if len(block_data) < 20:
+                    continue
+
+                interface_id, ts_high, ts_low, captured_len, original_len = (
+                    struct.unpack(f"{byte_order}IIIII", block_data[:20])
+                )
+
+                packet_data = block_data[20 : 20 + captured_len]
+                if len(packet_data) >= captured_len:
+                    yield from self._parse_packet(packet_data)
+
+            # Handle Simple Packet Block
+            elif block_type == PCAPNG_SIMPLE_PACKET_BLOCK:
+                # SPB format: original_len(4) + packet_data + padding + block_length(4)
+                if len(block_data) < 4:
+                    continue
+
+                _ = struct.unpack(f"{byte_order}I", block_data[:4])[0]  # original_len
+                # Captured length = block_length - 16 (headers) - padding
+                packet_data = block_data[4:-4]  # Exclude trailing block_length
+                if len(packet_data) > 0:
+                    yield from self._parse_packet(packet_data)
+
+    def _parse_packet(
+        self, packet_data: bytes
+    ) -> Generator[IEXDEEPMarketMessage, None, None]:
+        """Parse IEX DEEP messages from a network packet.
+
+        Args:
+            packet_data: Raw packet data
+
+        Yields:
+            IEXDEEPMarketMessage objects
+        """
+        # Try to find IEX-TP header in the packet
+        iex_tp_offset = self._find_iex_tp_header(packet_data)
+        if iex_tp_offset < 0:
+            return  # Not an IEX DEEP packet
+
+        # Parse IEX-TP header
+        iex_tp_data = packet_data[iex_tp_offset:]
+        if len(iex_tp_data) < IEX_TP_HEADER_SIZE:
+            return  # Truncated IEX-TP header
+
+        # IEX-TP header format (40 bytes, little endian):
+        # version(1) + reserved(1) + message_protocol_id(2) + channel_id(4) +
+        # session_id(4) + payload_length(2) + message_count(2) +
+        # stream_offset(8) + first_message_seq_num(8) + send_time(8)
+        (
+            version,
+            reserved,
+            message_protocol_id,
+            channel_id,
+            session_id,
+            payload_length,
+            message_count,
+            stream_offset,
+            first_message_seq_num,
+            send_time,
+        ) = struct.unpack("<BBHIIHHQQQ", iex_tp_data[:IEX_TP_HEADER_SIZE])
+
+        # Verify this is IEX DEEP
+        if message_protocol_id != IEX_DEEP_MESSAGE_PROTOCOL_ID:
+            return
+
+        # Parse messages from payload
+        payload = iex_tp_data[IEX_TP_HEADER_SIZE:]
+        offset = 0
+
+        for _ in range(message_count):
+            if offset + 2 > len(payload):
+                break
+
+            # Each message is prefixed with 2-byte length
+            msg_len = struct.unpack("<H", payload[offset : offset + 2])[0]
+            offset += 2
+
+            if offset + msg_len > len(payload):
+                break
+
+            msg_data = payload[offset : offset + msg_len]
+            offset += msg_len
+
+            if len(msg_data) > 0:
+                try:
+                    message = IEXDEEPMarketMessage.from_bytes(msg_data)
+                    yield message
+                except Exception:
+                    # Skip malformed messages
+                    continue
+
+    def _find_iex_tp_header(self, packet_data: bytes) -> int:
+        """Find the offset of the IEX-TP header in packet data.
+
+        Args:
+            packet_data: Raw packet data
+
+        Returns:
+            Offset to IEX-TP header, or -1 if not found
+        """
+        # Common offsets to check:
+        # - 42: Ethernet(14) + IP(20) + UDP(8)
+        # - 0: Raw IEX-TP (no encapsulation)
+        # - 14: Ethernet only
+        # - 34: Ethernet + IP (no UDP)
+
+        offsets_to_try = [42, 0, 14, 34]
+
+        for offset in offsets_to_try:
+            if offset + IEX_TP_HEADER_SIZE <= len(packet_data):
+                try:
+                    protocol_id = struct.unpack(
+                        "<H", packet_data[offset + 2 : offset + 4]
+                    )[0]
+                    if protocol_id == IEX_DEEP_MESSAGE_PROTOCOL_ID:
+                        return offset
+                except Exception:
+                    continue
+
+        return -1

--- a/tests/test_iex_deep_messages.py
+++ b/tests/test_iex_deep_messages.py
@@ -1,0 +1,213 @@
+"""Tests for IEX DEEP market message functionality."""
+
+import json
+import struct
+
+import pytest
+
+from meatpy.iex_deep.iex_deep_market_message import (
+    IEXDEEPMarketMessage,
+    SystemEventMessage,
+    SecurityDirectoryMessage,
+    TradingStatusMessage,
+    PriceLevelUpdateBuySideMessage,
+    PriceLevelUpdateSellSideMessage,
+    TradeReportMessage,
+)
+
+
+class TestSystemEventMessage:
+    """Test SystemEventMessage functionality."""
+
+    def test_from_bytes(self):
+        """Test creating message from bytes."""
+        # IEX DEEP format: message_type(1) + system_event(1) + timestamp(8)
+        timestamp = 1527599700000000000  # nanoseconds since POSIX epoch
+        system_event = b"O"  # Start of messages
+
+        # Pack the data in little endian
+        data = struct.pack("<c c q", b"S", system_event, timestamp)
+
+        # Create message from bytes
+        message = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(message, SystemEventMessage)
+        assert message.timestamp == timestamp
+        assert message.system_event == system_event
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = SystemEventMessage(system_event=b"O", timestamp=1527599700000000000)
+
+        data = message.to_bytes()
+
+        # Verify the packed data
+        expected = struct.pack("<c b q", b"S", ord(b"O"), 1527599700000000000)
+        assert data == expected
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        message = SystemEventMessage(system_event=b"O", timestamp=1527599700000000000)
+
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["timestamp"] == 1527599700000000000
+        assert data["message_type"] == "S"
+        assert data["system_event"] == "O"
+
+
+class TestSecurityDirectoryMessage:
+    """Test SecurityDirectoryMessage functionality."""
+
+    def test_from_bytes(self):
+        """Test creating message from bytes."""
+        # Format: message_type(1) + flags(1) + timestamp(8) + symbol(8) +
+        #         round_lot_size(4) + adjusted_poc_price(8) + luld_tier(1)
+        timestamp = 1527599700000000000
+        flags = 0x80  # Test flag bit
+        symbol = b"AAPL    "
+        round_lot_size = 100
+        adjusted_poc_price = 1500000  # $150.0000 (4 decimal places)
+        luld_tier = 1
+
+        data = struct.pack(
+            "<c B q 8s I q B",
+            b"D",
+            flags,
+            timestamp,
+            symbol,
+            round_lot_size,
+            adjusted_poc_price,
+            luld_tier,
+        )
+
+        message = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(message, SecurityDirectoryMessage)
+        assert message.timestamp == timestamp
+        assert message.flags == flags
+        assert message.symbol == symbol
+        assert message.round_lot_size == round_lot_size
+        assert message.adjusted_poc_price == adjusted_poc_price
+        assert message.luld_tier == luld_tier
+
+
+class TestPriceLevelUpdateMessage:
+    """Test PriceLevelUpdate messages functionality."""
+
+    def test_buy_side_from_bytes(self):
+        """Test creating buy side price level update from bytes."""
+        # Format: message_type(1) + event_flags(1) + timestamp(8) + symbol(8) +
+        #         size(4) + price(8)
+        timestamp = 1527599700000000000
+        event_flags = 0x01
+        symbol = b"SPY     "
+        size = 1000
+        price = 2700000  # $270.0000 (4 decimal places)
+
+        data = struct.pack(
+            "<c B q 8s I q", b"8", event_flags, timestamp, symbol, size, price
+        )
+
+        message = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(message, PriceLevelUpdateBuySideMessage)
+        assert message.timestamp == timestamp
+        assert message.event_flags == event_flags
+        assert message.symbol == symbol
+        assert message.size == size
+        assert message.price == price
+
+    def test_sell_side_from_bytes(self):
+        """Test creating sell side price level update from bytes."""
+        timestamp = 1527599700000000000
+        event_flags = 0x01
+        symbol = b"SPY     "
+        size = 500
+        price = 2701000  # $270.1000
+
+        data = struct.pack(
+            "<c B q 8s I q", b"5", event_flags, timestamp, symbol, size, price
+        )
+
+        message = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(message, PriceLevelUpdateSellSideMessage)
+        assert message.timestamp == timestamp
+        assert message.size == size
+        assert message.price == price
+
+
+class TestTradeReportMessage:
+    """Test TradeReportMessage functionality."""
+
+    def test_from_bytes(self):
+        """Test creating trade report from bytes."""
+        # Format: message_type(1) + sale_condition_flags(1) + timestamp(8) +
+        #         symbol(8) + size(4) + price(8) + trade_id(8)
+        timestamp = 1527599700000000000
+        sale_condition_flags = 0x00
+        symbol = b"AAPL    "
+        size = 100
+        price = 1850000  # $185.0000
+        trade_id = 12345678
+
+        data = struct.pack(
+            "<c B q 8s I q q",
+            b"T",
+            sale_condition_flags,
+            timestamp,
+            symbol,
+            size,
+            price,
+            trade_id,
+        )
+
+        message = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(message, TradeReportMessage)
+        assert message.timestamp == timestamp
+        assert message.symbol == symbol
+        assert message.size == size
+        assert message.price == price
+        assert message.trade_id == trade_id
+
+
+class TestTradingStatusMessage:
+    """Test TradingStatusMessage functionality."""
+
+    def test_from_bytes(self):
+        """Test creating trading status message from bytes."""
+        # Format: message_type(1) + trading_status(1) + timestamp(8) +
+        #         symbol(8) + reason(4)
+        timestamp = 1527599700000000000
+        trading_status = b"T"  # Trading
+        symbol = b"AAPL    "
+        reason = b"    "
+
+        data = struct.pack(
+            "<c c q 8s 4s", b"H", trading_status, timestamp, symbol, reason
+        )
+
+        message = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(message, TradingStatusMessage)
+        assert message.timestamp == timestamp
+        assert message.trading_status == trading_status
+        assert message.symbol == symbol
+        assert message.reason == reason
+
+
+class TestUnknownMessageType:
+    """Test handling of unknown message types."""
+
+    def test_unknown_message_type_raises(self):
+        """Test that unknown message type raises UnknownMessageTypeError."""
+        from meatpy.message_reader import UnknownMessageTypeError
+
+        # Create data with invalid message type
+        data = struct.pack("<c q", b"Z", 1527599700000000000)
+
+        with pytest.raises(UnknownMessageTypeError):
+            IEXDEEPMarketMessage.from_bytes(data)

--- a/tests/test_iex_deep_messages.py
+++ b/tests/test_iex_deep_messages.py
@@ -10,10 +10,17 @@ from meatpy.iex_deep.iex_deep_market_message import (
     SystemEventMessage,
     SecurityDirectoryMessage,
     TradingStatusMessage,
+    OperationalHaltStatusMessage,
+    ShortSalePriceTestStatusMessage,
+    SecurityEventMessage,
     PriceLevelUpdateBuySideMessage,
     PriceLevelUpdateSellSideMessage,
     TradeReportMessage,
+    OfficialPriceMessage,
+    TradeBreakMessage,
+    AuctionInformationMessage,
 )
+from meatpy.message_reader import UnknownMessageTypeError
 
 
 class TestSystemEventMessage:
@@ -21,14 +28,10 @@ class TestSystemEventMessage:
 
     def test_from_bytes(self):
         """Test creating message from bytes."""
-        # IEX DEEP format: message_type(1) + system_event(1) + timestamp(8)
-        timestamp = 1527599700000000000  # nanoseconds since POSIX epoch
-        system_event = b"O"  # Start of messages
+        timestamp = 1527599700000000000
+        system_event = b"O"
 
-        # Pack the data in little endian
         data = struct.pack("<c c q", b"S", system_event, timestamp)
-
-        # Create message from bytes
         message = IEXDEEPMarketMessage.from_bytes(data)
 
         assert isinstance(message, SystemEventMessage)
@@ -38,17 +41,13 @@ class TestSystemEventMessage:
     def test_to_bytes(self):
         """Test converting message to bytes."""
         message = SystemEventMessage(system_event=b"O", timestamp=1527599700000000000)
-
         data = message.to_bytes()
-
-        # Verify the packed data
         expected = struct.pack("<c b q", b"S", ord(b"O"), 1527599700000000000)
         assert data == expected
 
     def test_to_json(self):
         """Test JSON serialization."""
         message = SystemEventMessage(system_event=b"O", timestamp=1527599700000000000)
-
         json_str = message.to_json()
         data = json.loads(json_str)
 
@@ -56,19 +55,27 @@ class TestSystemEventMessage:
         assert data["message_type"] == "S"
         assert data["system_event"] == "O"
 
+    def test_roundtrip(self):
+        """Test that from_bytes(to_bytes()) returns equivalent message."""
+        original = SystemEventMessage(system_event=b"R", timestamp=1527599700000000000)
+        data = original.to_bytes()
+        restored = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(restored, SystemEventMessage)
+        assert restored.timestamp == original.timestamp
+        assert restored.system_event == original.system_event
+
 
 class TestSecurityDirectoryMessage:
     """Test SecurityDirectoryMessage functionality."""
 
     def test_from_bytes(self):
         """Test creating message from bytes."""
-        # Format: message_type(1) + flags(1) + timestamp(8) + symbol(8) +
-        #         round_lot_size(4) + adjusted_poc_price(8) + luld_tier(1)
         timestamp = 1527599700000000000
-        flags = 0x80  # Test flag bit
+        flags = 0x80
         symbol = b"AAPL    "
         round_lot_size = 100
-        adjusted_poc_price = 1500000  # $150.0000 (4 decimal places)
+        adjusted_poc_price = 1500000
         luld_tier = 1
 
         data = struct.pack(
@@ -92,19 +99,282 @@ class TestSecurityDirectoryMessage:
         assert message.adjusted_poc_price == adjusted_poc_price
         assert message.luld_tier == luld_tier
 
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = SecurityDirectoryMessage(
+            flags=0x80,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            round_lot_size=100,
+            adjusted_poc_price=1500000,
+            luld_tier=1,
+        )
+        data = message.to_bytes()
+        restored = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert restored.symbol == message.symbol
+        assert restored.round_lot_size == message.round_lot_size
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        message = SecurityDirectoryMessage(
+            flags=0x80,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            round_lot_size=100,
+            adjusted_poc_price=1500000,
+            luld_tier=1,
+        )
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["symbol"] == "AAPL"
+        assert data["round_lot_size"] == 100
+        assert data["adjusted_poc_price"] == 150.0
+        assert data["luld_tier"] == 1
+
+    def test_flag_properties(self):
+        """Test flag property methods."""
+        # Test security flag (bit 7)
+        message = SecurityDirectoryMessage(
+            flags=0x80,
+            timestamp=1527599700000000000,
+            symbol=b"TEST    ",
+            round_lot_size=100,
+            adjusted_poc_price=1000000,
+            luld_tier=1,
+        )
+        assert message.is_test_security is True
+        assert message.is_when_issued is False
+        assert message.is_etp is False
+
+        # When issued flag (bit 6)
+        message2 = SecurityDirectoryMessage(
+            flags=0x40,
+            timestamp=1527599700000000000,
+            symbol=b"TEST    ",
+            round_lot_size=100,
+            adjusted_poc_price=1000000,
+            luld_tier=1,
+        )
+        assert message2.is_test_security is False
+        assert message2.is_when_issued is True
+        assert message2.is_etp is False
+
+        # ETP flag (bit 5)
+        message3 = SecurityDirectoryMessage(
+            flags=0x20,
+            timestamp=1527599700000000000,
+            symbol=b"SPY     ",
+            round_lot_size=100,
+            adjusted_poc_price=2700000,
+            luld_tier=1,
+        )
+        assert message3.is_test_security is False
+        assert message3.is_when_issued is False
+        assert message3.is_etp is True
+
+
+class TestTradingStatusMessage:
+    """Test TradingStatusMessage functionality."""
+
+    def test_from_bytes(self):
+        """Test creating trading status message from bytes."""
+        timestamp = 1527599700000000000
+        trading_status = b"T"
+        symbol = b"AAPL    "
+        reason = b"    "
+
+        data = struct.pack(
+            "<c c q 8s 4s", b"H", trading_status, timestamp, symbol, reason
+        )
+
+        message = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(message, TradingStatusMessage)
+        assert message.timestamp == timestamp
+        assert message.trading_status == trading_status
+        assert message.symbol == symbol
+        assert message.reason == reason
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = TradingStatusMessage(
+            trading_status=b"H",
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            reason=b"HALT",
+        )
+        data = message.to_bytes()
+        restored = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert restored.trading_status == message.trading_status
+        assert restored.symbol == message.symbol
+        assert restored.reason == message.reason
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        message = TradingStatusMessage(
+            trading_status=b"T",
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            reason=b"    ",
+        )
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["trading_status"] == "T"
+        assert data["symbol"] == "AAPL"
+        assert data["reason"] == ""
+
+
+class TestOperationalHaltStatusMessage:
+    """Test OperationalHaltStatusMessage functionality."""
+
+    def test_from_bytes(self):
+        """Test creating operational halt message from bytes."""
+        timestamp = 1527599700000000000
+        status = b"O"
+        symbol = b"AAPL    "
+
+        data = struct.pack("<c c q 8s", b"O", status, timestamp, symbol)
+        message = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(message, OperationalHaltStatusMessage)
+        assert message.operational_halt_status == status
+        assert message.symbol == symbol
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = OperationalHaltStatusMessage(
+            operational_halt_status=b"N",
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+        )
+        data = message.to_bytes()
+        restored = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert restored.operational_halt_status == message.operational_halt_status
+        assert restored.symbol == message.symbol
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        message = OperationalHaltStatusMessage(
+            operational_halt_status=b"O",
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+        )
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["operational_halt_status"] == "O"
+        assert data["symbol"] == "AAPL"
+
+
+class TestShortSalePriceTestStatusMessage:
+    """Test ShortSalePriceTestStatusMessage functionality."""
+
+    def test_from_bytes(self):
+        """Test creating short sale message from bytes."""
+        timestamp = 1527599700000000000
+        status = 1  # In effect
+        symbol = b"AAPL    "
+        detail = b"A"
+
+        data = struct.pack("<c B q 8s c", b"P", status, timestamp, symbol, detail)
+        message = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(message, ShortSalePriceTestStatusMessage)
+        assert message.short_sale_price_test_status == status
+        assert message.symbol == symbol
+        assert message.detail == detail
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = ShortSalePriceTestStatusMessage(
+            short_sale_price_test_status=1,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            detail=b"A",
+        )
+        data = message.to_bytes()
+        restored = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert (
+            restored.short_sale_price_test_status
+            == message.short_sale_price_test_status
+        )
+        assert restored.symbol == message.symbol
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        message = ShortSalePriceTestStatusMessage(
+            short_sale_price_test_status=1,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            detail=b"A",
+        )
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["short_sale_price_test_status"] == 1
+        assert data["symbol"] == "AAPL"
+        assert data["detail"] == "A"
+
+
+class TestSecurityEventMessage:
+    """Test SecurityEventMessage functionality."""
+
+    def test_from_bytes(self):
+        """Test creating security event message from bytes."""
+        timestamp = 1527599700000000000
+        event = b"O"  # Opening Process Complete
+        symbol = b"AAPL    "
+
+        data = struct.pack("<c c q 8s", b"E", event, timestamp, symbol)
+        message = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(message, SecurityEventMessage)
+        assert message.security_event == event
+        assert message.symbol == symbol
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = SecurityEventMessage(
+            security_event=b"C",  # Closing Process Complete
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+        )
+        data = message.to_bytes()
+        restored = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert restored.security_event == message.security_event
+        assert restored.symbol == message.symbol
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        message = SecurityEventMessage(
+            security_event=b"O",
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+        )
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["security_event"] == "O"
+        assert data["symbol"] == "AAPL"
+
 
 class TestPriceLevelUpdateMessage:
     """Test PriceLevelUpdate messages functionality."""
 
     def test_buy_side_from_bytes(self):
         """Test creating buy side price level update from bytes."""
-        # Format: message_type(1) + event_flags(1) + timestamp(8) + symbol(8) +
-        #         size(4) + price(8)
         timestamp = 1527599700000000000
         event_flags = 0x01
         symbol = b"SPY     "
         size = 1000
-        price = 2700000  # $270.0000 (4 decimal places)
+        price = 2700000
 
         data = struct.pack(
             "<c B q 8s I q", b"8", event_flags, timestamp, symbol, size, price
@@ -125,7 +395,7 @@ class TestPriceLevelUpdateMessage:
         event_flags = 0x01
         symbol = b"SPY     "
         size = 500
-        price = 2701000  # $270.1000
+        price = 2701000
 
         data = struct.pack(
             "<c B q 8s I q", b"5", event_flags, timestamp, symbol, size, price
@@ -138,19 +408,65 @@ class TestPriceLevelUpdateMessage:
         assert message.size == size
         assert message.price == price
 
+    def test_buy_side_to_bytes(self):
+        """Test converting buy side message to bytes."""
+        message = PriceLevelUpdateBuySideMessage(
+            event_flags=0x01,
+            timestamp=1527599700000000000,
+            symbol=b"SPY     ",
+            size=1000,
+            price=2700000,
+        )
+        data = message.to_bytes()
+        restored = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(restored, PriceLevelUpdateBuySideMessage)
+        assert restored.price == message.price
+        assert restored.size == message.size
+
+    def test_sell_side_to_bytes(self):
+        """Test converting sell side message to bytes."""
+        message = PriceLevelUpdateSellSideMessage(
+            event_flags=0x01,
+            timestamp=1527599700000000000,
+            symbol=b"SPY     ",
+            size=500,
+            price=2701000,
+        )
+        data = message.to_bytes()
+        restored = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(restored, PriceLevelUpdateSellSideMessage)
+        assert restored.price == message.price
+        assert restored.size == message.size
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        message = PriceLevelUpdateBuySideMessage(
+            event_flags=0x01,
+            timestamp=1527599700000000000,
+            symbol=b"SPY     ",
+            size=1000,
+            price=2700000,
+        )
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["symbol"] == "SPY"
+        assert data["size"] == 1000
+        assert data["price"] == 270.0
+
 
 class TestTradeReportMessage:
     """Test TradeReportMessage functionality."""
 
     def test_from_bytes(self):
         """Test creating trade report from bytes."""
-        # Format: message_type(1) + sale_condition_flags(1) + timestamp(8) +
-        #         symbol(8) + size(4) + price(8) + trade_id(8)
         timestamp = 1527599700000000000
         sale_condition_flags = 0x00
         symbol = b"AAPL    "
         size = 100
-        price = 1850000  # $185.0000
+        price = 1850000
         trade_id = 12345678
 
         data = struct.pack(
@@ -173,30 +489,301 @@ class TestTradeReportMessage:
         assert message.price == price
         assert message.trade_id == trade_id
 
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = TradeReportMessage(
+            sale_condition_flags=0x00,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            size=100,
+            price=1850000,
+            trade_id=12345678,
+        )
+        data = message.to_bytes()
+        restored = IEXDEEPMarketMessage.from_bytes(data)
 
-class TestTradingStatusMessage:
-    """Test TradingStatusMessage functionality."""
+        assert restored.trade_id == message.trade_id
+        assert restored.price == message.price
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        message = TradeReportMessage(
+            sale_condition_flags=0x00,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            size=100,
+            price=1850000,
+            trade_id=12345678,
+        )
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["symbol"] == "AAPL"
+        assert data["size"] == 100
+        assert data["price"] == 185.0
+        assert data["trade_id"] == 12345678
+
+    def test_sale_condition_flags(self):
+        """Test sale condition flag properties."""
+        # ISO flag (bit 7)
+        message = TradeReportMessage(
+            sale_condition_flags=0x80,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            size=100,
+            price=1850000,
+            trade_id=12345678,
+        )
+        assert message.is_intermarket_sweep is True
+        assert message.is_extended_hours is False
+        assert message.is_odd_lot is False
+        assert message.is_trade_through_exempt is False
+        assert message.is_single_price_cross is False
+
+        # Extended hours (bit 6)
+        message2 = TradeReportMessage(
+            sale_condition_flags=0x40,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            size=100,
+            price=1850000,
+            trade_id=12345678,
+        )
+        assert message2.is_extended_hours is True
+
+        # Odd lot (bit 5)
+        message3 = TradeReportMessage(
+            sale_condition_flags=0x20,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            size=50,
+            price=1850000,
+            trade_id=12345678,
+        )
+        assert message3.is_odd_lot is True
+
+        # Trade through exempt (bit 4)
+        message4 = TradeReportMessage(
+            sale_condition_flags=0x10,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            size=100,
+            price=1850000,
+            trade_id=12345678,
+        )
+        assert message4.is_trade_through_exempt is True
+
+        # Single price cross (bit 3)
+        message5 = TradeReportMessage(
+            sale_condition_flags=0x08,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            size=100,
+            price=1850000,
+            trade_id=12345678,
+        )
+        assert message5.is_single_price_cross is True
+
+
+class TestOfficialPriceMessage:
+    """Test OfficialPriceMessage functionality."""
 
     def test_from_bytes(self):
-        """Test creating trading status message from bytes."""
-        # Format: message_type(1) + trading_status(1) + timestamp(8) +
-        #         symbol(8) + reason(4)
+        """Test creating official price message from bytes."""
         timestamp = 1527599700000000000
-        trading_status = b"T"  # Trading
+        price_type = b"Q"  # Opening price
         symbol = b"AAPL    "
-        reason = b"    "
+        price = 1850000
 
-        data = struct.pack(
-            "<c c q 8s 4s", b"H", trading_status, timestamp, symbol, reason
-        )
-
+        data = struct.pack("<c c q 8s q", b"X", price_type, timestamp, symbol, price)
         message = IEXDEEPMarketMessage.from_bytes(data)
 
-        assert isinstance(message, TradingStatusMessage)
-        assert message.timestamp == timestamp
-        assert message.trading_status == trading_status
+        assert isinstance(message, OfficialPriceMessage)
+        assert message.price_type == price_type
         assert message.symbol == symbol
-        assert message.reason == reason
+        assert message.official_price == price
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = OfficialPriceMessage(
+            price_type=b"M",  # Closing price
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            official_price=1855000,
+        )
+        data = message.to_bytes()
+        restored = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert restored.price_type == message.price_type
+        assert restored.official_price == message.official_price
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        message = OfficialPriceMessage(
+            price_type=b"Q",
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            official_price=1850000,
+        )
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["price_type"] == "Q"
+        assert data["symbol"] == "AAPL"
+        assert data["official_price"] == 185.0
+
+
+class TestTradeBreakMessage:
+    """Test TradeBreakMessage functionality."""
+
+    def test_from_bytes(self):
+        """Test creating trade break message from bytes."""
+        timestamp = 1527599700000000000
+        flags = 0x00
+        symbol = b"AAPL    "
+        size = 100
+        price = 1850000
+        trade_id = 12345678
+
+        data = struct.pack(
+            "<c B q 8s I q q", b"B", flags, timestamp, symbol, size, price, trade_id
+        )
+        message = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(message, TradeBreakMessage)
+        assert message.symbol == symbol
+        assert message.size == size
+        assert message.price == price
+        assert message.trade_id == trade_id
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = TradeBreakMessage(
+            sale_condition_flags=0x00,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            size=100,
+            price=1850000,
+            trade_id=12345678,
+        )
+        data = message.to_bytes()
+        restored = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert restored.trade_id == message.trade_id
+        assert restored.price == message.price
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        message = TradeBreakMessage(
+            sale_condition_flags=0x00,
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            size=100,
+            price=1850000,
+            trade_id=12345678,
+        )
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["symbol"] == "AAPL"
+        assert data["trade_id"] == 12345678
+
+
+class TestAuctionInformationMessage:
+    """Test AuctionInformationMessage functionality."""
+
+    def test_from_bytes(self):
+        """Test creating auction info message from bytes."""
+        timestamp = 1527599700000000000
+        auction_type = b"O"  # Opening
+        symbol = b"AAPL    "
+        paired_shares = 1000
+        reference_price = 1850000
+        indicative_clearing_price = 1851000
+        imbalance_shares = 200
+        imbalance_side = b"B"
+        extension_number = 0
+        scheduled_auction_time = 34200
+        auction_book_clearing_price = 1850500
+        collar_reference_price = 1850000
+        lower_auction_collar = 1840000
+        upper_auction_collar = 1860000
+
+        data = struct.pack(
+            "<c c q 8s I q q I c B I q q q q",
+            b"A",
+            auction_type,
+            timestamp,
+            symbol,
+            paired_shares,
+            reference_price,
+            indicative_clearing_price,
+            imbalance_shares,
+            imbalance_side,
+            extension_number,
+            scheduled_auction_time,
+            auction_book_clearing_price,
+            collar_reference_price,
+            lower_auction_collar,
+            upper_auction_collar,
+        )
+        message = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert isinstance(message, AuctionInformationMessage)
+        assert message.auction_type == auction_type
+        assert message.symbol == symbol
+        assert message.paired_shares == paired_shares
+        assert message.imbalance_side == imbalance_side
+
+    def test_to_bytes(self):
+        """Test converting message to bytes."""
+        message = AuctionInformationMessage(
+            auction_type=b"C",  # Closing
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            paired_shares=1000,
+            reference_price=1850000,
+            indicative_clearing_price=1851000,
+            imbalance_shares=200,
+            imbalance_side=b"S",
+            extension_number=0,
+            scheduled_auction_time=57600,
+            auction_book_clearing_price=1850500,
+            collar_reference_price=1850000,
+            lower_auction_collar=1840000,
+            upper_auction_collar=1860000,
+        )
+        data = message.to_bytes()
+        restored = IEXDEEPMarketMessage.from_bytes(data)
+
+        assert restored.auction_type == message.auction_type
+        assert restored.paired_shares == message.paired_shares
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        message = AuctionInformationMessage(
+            auction_type=b"O",
+            timestamp=1527599700000000000,
+            symbol=b"AAPL    ",
+            paired_shares=1000,
+            reference_price=1850000,
+            indicative_clearing_price=1851000,
+            imbalance_shares=200,
+            imbalance_side=b"B",
+            extension_number=0,
+            scheduled_auction_time=34200,
+            auction_book_clearing_price=1850500,
+            collar_reference_price=1850000,
+            lower_auction_collar=1840000,
+            upper_auction_collar=1860000,
+        )
+        json_str = message.to_json()
+        data = json.loads(json_str)
+
+        assert data["auction_type"] == "O"
+        assert data["symbol"] == "AAPL"
+        assert data["paired_shares"] == 1000
+        assert data["reference_price"] == 185.0
 
 
 class TestUnknownMessageType:
@@ -204,10 +791,12 @@ class TestUnknownMessageType:
 
     def test_unknown_message_type_raises(self):
         """Test that unknown message type raises UnknownMessageTypeError."""
-        from meatpy.message_reader import UnknownMessageTypeError
-
-        # Create data with invalid message type
         data = struct.pack("<c q", b"Z", 1527599700000000000)
 
         with pytest.raises(UnknownMessageTypeError):
             IEXDEEPMarketMessage.from_bytes(data)
+
+    def test_empty_data_raises(self):
+        """Test that empty data raises ValueError."""
+        with pytest.raises(ValueError):
+            IEXDEEPMarketMessage.from_bytes(b"")

--- a/tests/test_iex_deep_processor.py
+++ b/tests/test_iex_deep_processor.py
@@ -1,0 +1,211 @@
+"""Tests for IEX DEEP market processor functionality."""
+
+import struct
+
+
+from meatpy.iex_deep.iex_deep_market_processor import IEXDEEPMarketProcessor
+from meatpy.iex_deep.iex_deep_market_message import (
+    IEXDEEPMarketMessage,
+)
+
+
+def make_buy_price_level(
+    symbol: bytes, price: int, size: int, timestamp: int = 1527599700000000000
+):
+    """Helper to create a buy price level update message."""
+    data = struct.pack("<c B q 8s I q", b"8", 0x01, timestamp, symbol, size, price)
+    return IEXDEEPMarketMessage.from_bytes(data)
+
+
+def make_sell_price_level(
+    symbol: bytes, price: int, size: int, timestamp: int = 1527599700000000000
+):
+    """Helper to create a sell price level update message."""
+    data = struct.pack("<c B q 8s I q", b"5", 0x01, timestamp, symbol, size, price)
+    return IEXDEEPMarketMessage.from_bytes(data)
+
+
+def make_trade(
+    symbol: bytes,
+    price: int,
+    size: int,
+    trade_id: int,
+    timestamp: int = 1527599700000000000,
+):
+    """Helper to create a trade report message."""
+    data = struct.pack(
+        "<c B q 8s I q q", b"T", 0x00, timestamp, symbol, size, price, trade_id
+    )
+    return IEXDEEPMarketMessage.from_bytes(data)
+
+
+def make_system_event(system_event: bytes, timestamp: int = 1527599700000000000):
+    """Helper to create a system event message."""
+    data = struct.pack("<c c q", b"S", system_event, timestamp)
+    return IEXDEEPMarketMessage.from_bytes(data)
+
+
+def make_trading_status(
+    symbol: bytes, status: bytes, timestamp: int = 1527599700000000000
+):
+    """Helper to create a trading status message."""
+    data = struct.pack("<c c q 8s 4s", b"H", status, timestamp, symbol, b"    ")
+    return IEXDEEPMarketMessage.from_bytes(data)
+
+
+class TestIEXDEEPMarketProcessor:
+    """Test the IEXDEEPMarketProcessor class."""
+
+    def test_initialization(self):
+        """Test processor initialization."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+        assert processor.instrument == b"AAPL    "
+        assert processor._bid_levels == {}
+        assert processor._ask_levels == {}
+        assert processor.track_lob is False
+
+    def test_initialization_with_bytes_symbol(self):
+        """Test processor initialization with bytes symbol."""
+        processor = IEXDEEPMarketProcessor(b"SPY     ")
+        assert processor.instrument == b"SPY     "
+
+    def test_price_level_update_bid(self):
+        """Test processing bid price level update."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_buy_price_level(b"AAPL    ", 1850000, 1000)
+        processor.process_message(message)
+
+        assert 1850000 in processor._bid_levels
+        assert processor._bid_levels[1850000] == 1000
+
+    def test_price_level_update_ask(self):
+        """Test processing ask price level update."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_sell_price_level(b"AAPL    ", 1851000, 500)
+        processor.process_message(message)
+
+        assert 1851000 in processor._ask_levels
+        assert processor._ask_levels[1851000] == 500
+
+    def test_price_level_removal(self):
+        """Test that size=0 removes a price level."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # Add a price level
+        message1 = make_buy_price_level(b"AAPL    ", 1850000, 1000)
+        processor.process_message(message1)
+
+        assert 1850000 in processor._bid_levels
+
+        # Remove the price level with size=0
+        message2 = make_buy_price_level(b"AAPL    ", 1850000, 0)
+        processor.process_message(message2)
+
+        assert 1850000 not in processor._bid_levels
+
+    def test_get_best_bid(self):
+        """Test getting best bid."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # Add multiple bid levels
+        for price, size in [(1850000, 1000), (1849000, 500), (1851000, 200)]:
+            message = make_buy_price_level(b"AAPL    ", price, size)
+            processor.process_message(message)
+
+        best_bid = processor.get_best_bid()
+        assert best_bid is not None
+        assert best_bid[0] == 1851000  # Highest bid price
+        assert best_bid[1] == 200
+
+    def test_get_best_ask(self):
+        """Test getting best ask."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # Add multiple ask levels
+        for price, size in [(1852000, 1000), (1853000, 500), (1851000, 200)]:
+            message = make_sell_price_level(b"AAPL    ", price, size)
+            processor.process_message(message)
+
+        best_ask = processor.get_best_ask()
+        assert best_ask is not None
+        assert best_ask[0] == 1851000  # Lowest ask price
+        assert best_ask[1] == 200
+
+    def test_get_bbo(self):
+        """Test getting best bid and offer."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # Add bid level
+        bid_msg = make_buy_price_level(b"AAPL    ", 1850000, 1000)
+        processor.process_message(bid_msg)
+
+        # Add ask level
+        ask_msg = make_sell_price_level(b"AAPL    ", 1851000, 500)
+        processor.process_message(ask_msg)
+
+        bbo = processor.get_bbo()
+        assert bbo[0] == (1850000, 1000)  # Best bid
+        assert bbo[1] == (1851000, 500)  # Best ask
+
+    def test_trade_processing(self):
+        """Test processing trade messages."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_trade(b"AAPL    ", 1850000, 100, 12345)
+        processor.process_message(message)
+
+        assert 12345 in processor._trade_ids
+
+    def test_ignores_other_symbols(self):
+        """Test that processor ignores messages for other symbols."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # Create message for different symbol
+        message = make_buy_price_level(b"GOOG    ", 1500000, 100)
+        processor.process_message(message)
+
+        # Should not be processed
+        assert len(processor._bid_levels) == 0
+
+    def test_timestamp_adjustment(self):
+        """Test timestamp conversion."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # May 29, 2018 12:00:00 UTC in nanoseconds since epoch
+        raw_timestamp = 1527595200000000000
+
+        ts = processor.adjust_timestamp(raw_timestamp)
+
+        # Timestamp is a subclass of datetime, so it has year/month/day properties
+        assert ts.year == 2018
+        assert ts.month == 5
+        assert ts.day == 29
+
+    def test_system_event_processing(self):
+        """Test processing system event messages."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_system_event(b"O")
+        processor.process_message(message)
+
+        assert processor.system_status == b"O"
+
+    def test_trading_status_processing(self):
+        """Test processing trading status messages."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_trading_status(b"AAPL    ", b"T")
+        processor.process_message(message)
+
+        assert processor.trading_status_code == b"T"
+
+    def test_empty_book_returns_none(self):
+        """Test that empty book returns None for BBO."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        assert processor.get_best_bid() is None
+        assert processor.get_best_ask() is None
+        bbo = processor.get_bbo()
+        assert bbo == (None, None)

--- a/tests/test_iex_deep_processor.py
+++ b/tests/test_iex_deep_processor.py
@@ -2,10 +2,16 @@
 
 import struct
 
-
-from meatpy.iex_deep.iex_deep_market_processor import IEXDEEPMarketProcessor
-from meatpy.iex_deep.iex_deep_market_message import (
-    IEXDEEPMarketMessage,
+from meatpy.iex_deep.iex_deep_market_processor import (
+    IEXDEEPMarketProcessor,
+    InvalidMessageTypeError,
+)
+from meatpy.iex_deep.iex_deep_market_message import IEXDEEPMarketMessage
+from meatpy.trading_status import (
+    HaltedTradingStatus,
+    PreTradeTradingStatus,
+    TradeTradingStatus,
+    PostTradeTradingStatus,
 )
 
 
@@ -39,6 +45,20 @@ def make_trade(
     return IEXDEEPMarketMessage.from_bytes(data)
 
 
+def make_trade_break(
+    symbol: bytes,
+    price: int,
+    size: int,
+    trade_id: int,
+    timestamp: int = 1527599700000000000,
+):
+    """Helper to create a trade break message."""
+    data = struct.pack(
+        "<c B q 8s I q q", b"B", 0x00, timestamp, symbol, size, price, trade_id
+    )
+    return IEXDEEPMarketMessage.from_bytes(data)
+
+
 def make_system_event(system_event: bytes, timestamp: int = 1527599700000000000):
     """Helper to create a system event message."""
     data = struct.pack("<c c q", b"S", system_event, timestamp)
@@ -50,6 +70,78 @@ def make_trading_status(
 ):
     """Helper to create a trading status message."""
     data = struct.pack("<c c q 8s 4s", b"H", status, timestamp, symbol, b"    ")
+    return IEXDEEPMarketMessage.from_bytes(data)
+
+
+def make_operational_halt(
+    symbol: bytes, status: bytes, timestamp: int = 1527599700000000000
+):
+    """Helper to create an operational halt message."""
+    data = struct.pack("<c c q 8s", b"O", status, timestamp, symbol)
+    return IEXDEEPMarketMessage.from_bytes(data)
+
+
+def make_short_sale_status(
+    symbol: bytes, status: int, timestamp: int = 1527599700000000000
+):
+    """Helper to create a short sale status message."""
+    data = struct.pack("<c B q 8s c", b"P", status, timestamp, symbol, b"A")
+    return IEXDEEPMarketMessage.from_bytes(data)
+
+
+def make_security_event(
+    symbol: bytes, event: bytes, timestamp: int = 1527599700000000000
+):
+    """Helper to create a security event message."""
+    data = struct.pack("<c c q 8s", b"E", event, timestamp, symbol)
+    return IEXDEEPMarketMessage.from_bytes(data)
+
+
+def make_official_price(
+    symbol: bytes, price_type: bytes, price: int, timestamp: int = 1527599700000000000
+):
+    """Helper to create an official price message."""
+    data = struct.pack("<c c q 8s q", b"X", price_type, timestamp, symbol, price)
+    return IEXDEEPMarketMessage.from_bytes(data)
+
+
+def make_security_directory(symbol: bytes, timestamp: int = 1527599700000000000):
+    """Helper to create a security directory message."""
+    data = struct.pack(
+        "<c B q 8s I q B",
+        b"D",
+        0x00,  # flags
+        timestamp,
+        symbol,
+        100,  # round_lot_size
+        1500000,  # adjusted_poc_price
+        1,  # luld_tier
+    )
+    return IEXDEEPMarketMessage.from_bytes(data)
+
+
+def make_auction_info(
+    symbol: bytes, auction_type: bytes, timestamp: int = 1527599700000000000
+):
+    """Helper to create an auction information message."""
+    data = struct.pack(
+        "<c c q 8s I q q I c B I q q q q",
+        b"A",
+        auction_type,
+        timestamp,
+        symbol,
+        1000,  # paired_shares
+        1850000,  # reference_price
+        1851000,  # indicative_clearing_price
+        200,  # imbalance_shares
+        b"B",  # imbalance_side
+        0,  # extension_number
+        34200,  # scheduled_auction_time
+        1850500,  # auction_book_clearing_price
+        1850000,  # collar_reference_price
+        1840000,  # lower_auction_collar
+        1860000,  # upper_auction_collar
+    )
     return IEXDEEPMarketMessage.from_bytes(data)
 
 
@@ -105,6 +197,20 @@ class TestIEXDEEPMarketProcessor:
 
         assert 1850000 not in processor._bid_levels
 
+    def test_ask_level_removal(self):
+        """Test that size=0 removes an ask price level."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # Add an ask level
+        message1 = make_sell_price_level(b"AAPL    ", 1851000, 500)
+        processor.process_message(message1)
+        assert 1851000 in processor._ask_levels
+
+        # Remove with size=0
+        message2 = make_sell_price_level(b"AAPL    ", 1851000, 0)
+        processor.process_message(message2)
+        assert 1851000 not in processor._ask_levels
+
     def test_get_best_bid(self):
         """Test getting best bid."""
         processor = IEXDEEPMarketProcessor("AAPL")
@@ -158,6 +264,20 @@ class TestIEXDEEPMarketProcessor:
 
         assert 12345 in processor._trade_ids
 
+    def test_trade_break_processing(self):
+        """Test processing trade break messages."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # First add a trade
+        trade_msg = make_trade(b"AAPL    ", 1850000, 100, 12345)
+        processor.process_message(trade_msg)
+        assert 12345 in processor._trade_ids
+
+        # Then break it
+        break_msg = make_trade_break(b"AAPL    ", 1850000, 100, 12345)
+        processor.process_message(break_msg)
+        assert 12345 not in processor._trade_ids
+
     def test_ignores_other_symbols(self):
         """Test that processor ignores messages for other symbols."""
         processor = IEXDEEPMarketProcessor("AAPL")
@@ -209,3 +329,225 @@ class TestIEXDEEPMarketProcessor:
         assert processor.get_best_ask() is None
         bbo = processor.get_bbo()
         assert bbo == (None, None)
+
+    def test_trading_status_halted(self):
+        """Test trading status transitions to halted."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # Trading halted status
+        message = make_trading_status(b"AAPL    ", b"H")
+        processor.process_message(message)
+
+        assert isinstance(processor.trading_status, HaltedTradingStatus)
+
+    def test_trading_status_paused(self):
+        """Test trading status transitions to paused (halted)."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_trading_status(b"AAPL    ", b"P")
+        processor.process_message(message)
+
+        assert isinstance(processor.trading_status, HaltedTradingStatus)
+
+    def test_trading_status_order_acceptance(self):
+        """Test trading status transitions to order acceptance (pre-trade)."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_trading_status(b"AAPL    ", b"O")
+        processor.process_message(message)
+
+        assert isinstance(processor.trading_status, PreTradeTradingStatus)
+
+    def test_trading_status_trading(self):
+        """Test trading status transitions to trading."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_trading_status(b"AAPL    ", b"T")
+        processor.process_message(message)
+
+        assert isinstance(processor.trading_status, TradeTradingStatus)
+
+    def test_operational_halt_processing(self):
+        """Test processing operational halt messages."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_operational_halt(b"AAPL    ", b"O")
+        processor.process_message(message)
+
+        assert processor.operational_halt_status == b"O"
+        assert isinstance(processor.trading_status, HaltedTradingStatus)
+
+    def test_operational_halt_cleared(self):
+        """Test operational halt cleared."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # First halt
+        halt_msg = make_operational_halt(b"AAPL    ", b"O")
+        processor.process_message(halt_msg)
+        assert isinstance(processor.trading_status, HaltedTradingStatus)
+
+        # Then clear
+        clear_msg = make_operational_halt(b"AAPL    ", b"N")
+        processor.process_message(clear_msg)
+        assert processor.operational_halt_status == b"N"
+
+    def test_short_sale_status_processing(self):
+        """Test processing short sale status messages."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_short_sale_status(b"AAPL    ", 1)
+        processor.process_message(message)
+
+        assert processor.short_sale_status == 1
+
+    def test_security_event_processing(self):
+        """Test processing security event messages."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # Opening process complete
+        message = make_security_event(b"AAPL    ", b"O")
+        processor.process_message(message)
+        # Security events are processed but don't change state directly
+
+    def test_official_price_processing(self):
+        """Test processing official price messages."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # Opening price
+        message = make_official_price(b"AAPL    ", b"Q", 1850000)
+        processor.process_message(message)
+        # Official prices trigger events for handlers
+
+    def test_auction_info_processing(self):
+        """Test processing auction information messages."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_auction_info(b"AAPL    ", b"O")
+        processor.process_message(message)
+        # Auction info triggers events for handlers
+
+    def test_security_directory_processing(self):
+        """Test processing security directory messages."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_security_directory(b"AAPL    ")
+        processor.process_message(message)
+        # Security directory is processed for matching symbols
+
+    def test_security_directory_other_symbol(self):
+        """Test security directory for non-matching symbol is ignored."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_security_directory(b"GOOG    ")
+        processor.process_message(message)
+        # Should not affect processor state
+
+    def test_system_event_start_of_messages(self):
+        """Test system event start of messages sets pre-trade status."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_system_event(b"O")
+        processor.process_message(message)
+
+        assert processor.system_status == b"O"
+        assert isinstance(processor.trading_status, PreTradeTradingStatus)
+
+    def test_system_event_start_of_system_hours(self):
+        """Test system event start of system hours."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_system_event(b"S")
+        processor.process_message(message)
+
+        assert processor.system_status == b"S"
+        assert isinstance(processor.trading_status, PreTradeTradingStatus)
+
+    def test_system_event_start_of_regular_hours(self):
+        """Test system event start of regular market hours."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_system_event(b"R")
+        processor.process_message(message)
+
+        assert processor.system_status == b"R"
+        assert isinstance(processor.trading_status, TradeTradingStatus)
+
+    def test_system_event_end_of_regular_hours(self):
+        """Test system event end of regular market hours."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_system_event(b"M")
+        processor.process_message(message)
+
+        assert processor.system_status == b"M"
+        assert isinstance(processor.trading_status, PostTradeTradingStatus)
+
+    def test_system_event_end_of_system_hours(self):
+        """Test system event end of system hours."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_system_event(b"E")
+        processor.process_message(message)
+
+        assert processor.system_status == b"E"
+        assert isinstance(processor.trading_status, PostTradeTradingStatus)
+
+    def test_system_event_end_of_messages(self):
+        """Test system event end of messages."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        message = make_system_event(b"C")
+        processor.process_message(message)
+
+        assert processor.system_status == b"C"
+        assert isinstance(processor.trading_status, PostTradeTradingStatus)
+
+    def test_invalid_message_type(self):
+        """Test that non-IEX DEEP messages raise error."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # Create a mock message that's not an IEXDEEPMarketMessage
+        class FakeMessage:
+            pass
+
+        try:
+            processor.process_message(FakeMessage())
+            assert False, "Should have raised InvalidMessageTypeError"
+        except InvalidMessageTypeError:
+            pass
+
+    def test_messages_for_other_symbols_ignored(self):
+        """Test that all message types for other symbols are ignored."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # Try various message types for wrong symbol
+        processor.process_message(make_trading_status(b"GOOG    ", b"T"))
+        processor.process_message(make_operational_halt(b"GOOG    ", b"O"))
+        processor.process_message(make_short_sale_status(b"GOOG    ", 1))
+        processor.process_message(make_security_event(b"GOOG    ", b"O"))
+        processor.process_message(make_official_price(b"GOOG    ", b"Q", 1000000))
+        processor.process_message(make_trade(b"GOOG    ", 1000000, 100, 999))
+        processor.process_message(make_trade_break(b"GOOG    ", 1000000, 100, 999))
+        processor.process_message(make_auction_info(b"GOOG    ", b"O"))
+
+        # None should affect AAPL processor state
+        assert processor.trading_status_code == b""
+        assert processor.operational_halt_status == b""
+        assert processor.short_sale_status == 0
+        assert len(processor._trade_ids) == 0
+
+    def test_price_level_update_size(self):
+        """Test price level size updates."""
+        processor = IEXDEEPMarketProcessor("AAPL")
+
+        # Add initial level
+        processor.process_message(make_buy_price_level(b"AAPL    ", 1850000, 1000))
+        assert processor._bid_levels[1850000] == 1000
+
+        # Update size
+        processor.process_message(make_buy_price_level(b"AAPL    ", 1850000, 1500))
+        assert processor._bid_levels[1850000] == 1500
+
+        # Update size again
+        processor.process_message(make_buy_price_level(b"AAPL    ", 1850000, 500))
+        assert processor._bid_levels[1850000] == 500

--- a/uv.lock
+++ b/uv.lock
@@ -827,7 +827,7 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.4.4"
+version = "4.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
@@ -844,9 +844,9 @@ dependencies = [
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/4d/7ca5b46ea56742880d71a768a9e6fb8f8482228427eb89492d55c5d0bb7d/jupyterlab-4.4.4.tar.gz", hash = "sha256:163fee1ef702e0a057f75d2eed3ed1da8a986d59eb002cbeb6f0c2779e6cd153", size = 23044296, upload-time = "2025-06-28T13:07:20.708Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/f1/062e250e4126babed8b62ed3dbe47dfb4761e310a235a815e87b4fe330a3/jupyterlab-4.4.8.tar.gz", hash = "sha256:a89e5a2e9f9295ae039356fc5247e5bfac64936126ab805e3ff8e47f385b0c7e", size = 22967507, upload-time = "2025-09-25T17:26:38.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/82/66910ce0995dbfdb33609f41c99fe32ce483b9624a3e7d672af14ff63b9f/jupyterlab-4.4.4-py3-none-any.whl", hash = "sha256:711611e4f59851152eb93316c3547c3ec6291f16bb455f1f4fa380d25637e0dd", size = 12296310, upload-time = "2025-06-28T13:07:15.676Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3b/82d8c000648e77a112b2ae38e49722ffea808933377ea4a4867694384774/jupyterlab-4.4.8-py3-none-any.whl", hash = "sha256:81b56f33f35be15150e7ccd43440963a93d2b115ffa614a06d38b91e4d650f92", size = 12292452, upload-time = "2025-09-25T17:26:34.289Z" },
 ]
 
 [[package]]
@@ -1005,7 +1005,7 @@ wheels = [
 
 [[package]]
 name = "meatpy"
-version = "0.2.10"
+version = "0.2.11"
 source = { editable = "." }
 dependencies = [
     { name = "pyarrow" },

--- a/uv.lock
+++ b/uv.lock
@@ -1005,7 +1005,7 @@ wheels = [
 
 [[package]]
 name = "meatpy"
-version = "0.2.10"
+version = "0.2.11"
 source = { editable = "." }
 dependencies = [
     { name = "pyarrow" },
@@ -1591,15 +1591,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.16"
+version = "10.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/0a/c06b542ac108bfc73200677309cd9188a3a01b127a63f20cadc18d873d88/pymdown_extensions-10.16.tar.gz", hash = "sha256:71dac4fca63fabeffd3eb9038b756161a33ec6e8d230853d3cecf562155ab3de", size = 853197, upload-time = "2025-06-21T17:56:36.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/b3/6d2b3f149bc5413b0a29761c2c5832d8ce904a1d7f621e86616d96f505cc/pymdown_extensions-10.16.1.tar.gz", hash = "sha256:aace82bcccba3efc03e25d584e6a22d27a8e17caa3f4dd9f207e49b787aa9a91", size = 853277, upload-time = "2025-07-28T16:19:34.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/d4/10bb14004d3c792811e05e21b5e5dcae805aacb739bd12a0540967b99592/pymdown_extensions-10.16-py3-none-any.whl", hash = "sha256:f5dd064a4db588cb2d95229fc4ee63a1b16cc8b4d0e6145c0899ed8723da1df2", size = 266143, upload-time = "2025-06-21T17:56:35.356Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/06/43084e6cbd4b3bc0e80f6be743b2e79fbc6eed8de9ad8c629939fa55d972/pymdown_extensions-10.16.1-py3-none-any.whl", hash = "sha256:d6ba157a6c03146a7fb122b2b9a121300056384eafeec9c9f9e584adfdb2a32d", size = 266178, upload-time = "2025-07-28T16:19:31.401Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1005,7 +1005,7 @@ wheels = [
 
 [[package]]
 name = "meatpy"
-version = "0.2.10"
+version = "0.2.11"
 source = { editable = "." }
 dependencies = [
     { name = "pyarrow" },
@@ -2148,11 +2148,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements GitHub issue #82: Add support for IEX DEEP format.

This PR adds a new `iex_deep` module with complete support for reading and processing IEX DEEP 1.0 market data:

- **Message Types**: All 12 IEX DEEP message types (SystemEvent, SecurityDirectory, TradingStatus, OperationalHalt, ShortSalePriceTest, SecurityEvent, PriceLevelUpdate Buy/Sell, TradeReport, OfficialPrice, TradeBreak, AuctionInformation)

- **IEXDEEPMessageReader**: Reads PCAP and PCAP-NG format files with IEX-TP transport protocol parsing. Supports compressed files (.gz, .bz2, .xz, .zip)

- **IEXDEEPMarketProcessor**: Reconstructs order book from price-level updates with `get_best_bid()`, `get_best_ask()`, and `get_bbo()` methods

### Key Differences from ITCH

| Feature | IEX DEEP | NASDAQ ITCH |
|---------|----------|-------------|
| Byte order | Little endian | Big endian |
| Timestamps | Nanoseconds since POSIX epoch | Nanoseconds since midnight |
| Data granularity | Price levels (aggregated) | Individual orders |
| File format | PCAP/PCAP-NG | Raw binary |

### Files Added
- `src/meatpy/iex_deep/` - New module with message types, reader, and processor
- `tests/test_iex_deep_messages.py` - Unit tests for message parsing
- `tests/test_iex_deep_processor.py` - Unit tests for processor
- `docs/guide/iex-deep.md` - Comprehensive documentation

### Validation
Tested with sample IEX DEEP data files:
- Successfully parsed 100k+ messages from PCAP-NG files
- Verified order book reconstruction for TLT, SPY, and other symbols
- Confirmed correct BBO calculation and trade tracking

## Test plan
- [x] All existing tests pass (419 passed)
- [x] New IEX DEEP tests pass (23 passed)
- [x] Ruff check passes
- [x] Documentation builds successfully

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)